### PR TITLE
feat: add Obsidian-style graph view for visualizing note connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onyx",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onyx",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
@@ -34,7 +34,9 @@
         "qrcode.react": "^4.2.0",
         "remark-wiki-link": "^2.0.1",
         "solid-js": "^1.9.10",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "vis-data": "^8.0.3",
+        "vis-network": "^10.0.2"
       },
       "devDependencies": {
         "@tauri-apps/api": "^2.9.1",
@@ -471,6 +473,19 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2094,6 +2109,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
@@ -2410,6 +2432,19 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-2.0.0.tgz",
+      "integrity": "sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2775,6 +2810,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/keycharm": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.4.0.tgz",
+      "integrity": "sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peer": true
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -4568,6 +4610,56 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vis-data": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-8.0.3.tgz",
+      "integrity": "sha512-jhnb6rJNqkKR1Qmlay0VuDXY9ZlvAnYN1udsrP4U+krgZEq7C0yNSKdZqmnCe13mdnf9AdVcdDGFOzy2mpPoqw==",
+      "license": "(Apache-2.0 OR MIT)",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "vis-util": ">=6.0.0"
+      }
+    },
+    "node_modules/vis-network": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-10.0.2.tgz",
+      "integrity": "sha512-qPl8GLYBeHEFqiTqp4VBbYQIJ2EA8KLr7TstA2E8nJxfEHaKCU81hQLz7hhq11NUpHbMaRzBjW5uZpVKJ45/wA==",
+      "license": "(Apache-2.0 OR MIT)",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0 || ^2.0.0",
+        "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "vis-data": ">=8.0.0",
+        "vis-util": ">=6.0.0"
+      }
+    },
+    "node_modules/vis-util": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-6.0.0.tgz",
+      "integrity": "sha512-qtpts3HRma0zPe4bO7t9A2uejkRNj8Z2Tb6do6lN85iPNWExFkUiVhdAq5uLGIUqBFduyYeqWJKv/jMkxX0R5g==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0 || ^2.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "qrcode.react": "^4.2.0",
     "remark-wiki-link": "^2.0.1",
     "solid-js": "^1.9.10",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "vis-data": "^8.0.3",
+    "vis-network": "^10.0.2"
   },
   "devDependencies": {
     "@tauri-apps/api": "^2.9.1",

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -1,0 +1,309 @@
+import { Component, createSignal, createEffect, onCleanup, onMount, Show } from 'solid-js';
+import { Network, Options } from 'vis-network';
+import { DataSet } from 'vis-data';
+import { NoteGraph, NoteIndex, buildNoteGraph, buildLocalGraph } from '../lib/editor/note-index';
+import { invoke } from '@tauri-apps/api/core';
+
+interface GraphViewProps {
+  vaultPath: string | null;
+  noteIndex: NoteIndex | null;
+  currentFile: string | null;
+  onNodeClick: (path: string) => void;
+}
+
+const GraphView: Component<GraphViewProps> = (props) => {
+  const [loading, setLoading] = createSignal(true); // Start loading
+  const [localMode, setLocalMode] = createSignal(false);
+  const [depth, setDepth] = createSignal(1);
+  const [graphData, setGraphData] = createSignal<NoteGraph | null>(null);
+  const [nodeCount, setNodeCount] = createSignal(0);
+  const [linkCount, setLinkCount] = createSignal(0);
+  const [containerReady, setContainerReady] = createSignal(false);
+
+  let containerRef: HTMLDivElement | undefined;
+  let networkInstance: Network | null = null;
+
+  // Read file helper
+  const readFile = async (path: string): Promise<string> => {
+    return await invoke<string>('read_file', { path });
+  };
+
+  // Build the graph when vault/index changes
+  const rebuildGraph = async () => {
+    if (!props.vaultPath || !props.noteIndex) {
+      setGraphData(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const graph = await buildNoteGraph(props.vaultPath, props.noteIndex, readFile);
+      setGraphData(graph);
+      setNodeCount(graph.nodes.length);
+      setLinkCount(graph.links.length);
+    } catch (err) {
+      console.error('Failed to build graph:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Initialize container ref
+  const initContainer = (el: HTMLDivElement) => {
+    containerRef = el;
+    setContainerReady(true);
+  };
+
+  // Get the graph to display (filtered for local mode)
+  const getDisplayGraph = (): NoteGraph | null => {
+    const fullGraph = graphData();
+    if (!fullGraph) return null;
+
+    if (localMode() && props.currentFile) {
+      return buildLocalGraph(props.currentFile, fullGraph, depth());
+    }
+
+    return fullGraph;
+  };
+
+  // Render the graph using vis-network
+  const renderGraph = () => {
+    if (!containerRef) return;
+
+    const displayGraph = getDisplayGraph();
+    if (!displayGraph) {
+      if (networkInstance) {
+        networkInstance.destroy();
+        networkInstance = null;
+      }
+      return;
+    }
+
+    // Convert to vis-network format
+    const nodes = new DataSet(
+      displayGraph.nodes.map((node) => ({
+        id: node.id,
+        label: node.name,
+        title: `${node.name}\nIncoming: ${node.incomingCount}\nOutgoing: ${node.outgoingCount}`,
+        // Size based on incoming links (min 10, max 40)
+        size: Math.min(40, Math.max(10, 10 + node.incomingCount * 3)),
+        color: {
+          background: node.id === props.currentFile ? '#a78bfa' : '#6d6d80',
+          border: node.id === props.currentFile ? '#c4b5fd' : '#8b8b9e',
+          highlight: {
+            background: '#a78bfa',
+            border: '#c4b5fd',
+          },
+          hover: {
+            background: '#8b7cc9',
+            border: '#a78bfa',
+          },
+        },
+        font: {
+          color: '#e4e4e7',
+          size: 12,
+        },
+      }))
+    );
+
+    const edges = new DataSet(
+      displayGraph.links
+        .filter((link) => link.exists) // Only show links to existing notes
+        .map((link, index) => ({
+          id: index,
+          from: link.from,
+          to: link.to,
+          color: {
+            color: '#52525b',
+            highlight: '#a78bfa',
+            hover: '#71717a',
+          },
+          width: 1,
+        }))
+    );
+
+    const options: Options = {
+      nodes: {
+        shape: 'dot',
+        borderWidth: 2,
+        shadow: false,
+      },
+      edges: {
+        smooth: {
+          enabled: true,
+          type: 'continuous',
+          roundness: 0.5,
+        },
+        arrows: {
+          to: {
+            enabled: false,
+          },
+        },
+      },
+      physics: {
+        enabled: true,
+        solver: 'forceAtlas2Based',
+        forceAtlas2Based: {
+          gravitationalConstant: -50,
+          centralGravity: 0.01,
+          springLength: 100,
+          springConstant: 0.08,
+          damping: 0.4,
+          avoidOverlap: 0.5,
+        },
+        stabilization: {
+          enabled: true,
+          iterations: 200,
+          updateInterval: 25,
+        },
+      },
+      interaction: {
+        hover: true,
+        tooltipDelay: 200,
+        zoomView: true,
+        dragView: true,
+      },
+    };
+
+    if (networkInstance) {
+      networkInstance.destroy();
+    }
+
+    networkInstance = new Network(containerRef, { nodes, edges }, options);
+
+    // Handle node clicks
+    networkInstance.on('click', (params) => {
+      if (params.nodes.length > 0) {
+        const nodeId = params.nodes[0] as string;
+        props.onNodeClick(nodeId);
+      }
+    });
+
+    // Handle double-click to focus
+    networkInstance.on('doubleClick', (params) => {
+      if (params.nodes.length > 0) {
+        networkInstance?.focus(params.nodes[0], {
+          scale: 1.5,
+          animation: {
+            duration: 500,
+            easingFunction: 'easeInOutQuad',
+          },
+        });
+      }
+    });
+  };
+
+  // Build graph on mount and when vault/index changes
+  onMount(() => {
+    if (props.vaultPath && props.noteIndex) {
+      rebuildGraph();
+    }
+  });
+
+  // Rebuild graph when vault or index changes
+  createEffect(() => {
+    const vp = props.vaultPath;
+    const ni = props.noteIndex;
+    if (vp && ni) {
+      rebuildGraph();
+    }
+  });
+
+  // Re-render when graph data, mode, depth, current file, or container changes
+  createEffect(() => {
+    const data = graphData();
+    const mode = localMode();
+    const d = depth();
+    const file = props.currentFile;
+    const ready = containerReady();
+
+    // Only render when container is ready and we have data
+    if (ready && data) {
+      renderGraph();
+    }
+  });
+
+  // Cleanup on unmount
+  onCleanup(() => {
+    if (networkInstance) {
+      networkInstance.destroy();
+      networkInstance = null;
+    }
+  });
+
+  return (
+    <div class="graph-view">
+      <div class="graph-header">
+        <span class="graph-title">Graph View</span>
+        <button
+          class="graph-refresh-btn"
+          onClick={rebuildGraph}
+          disabled={loading()}
+          title="Refresh graph"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M23 4v6h-6"></path>
+            <path d="M1 20v-6h6"></path>
+            <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
+          </svg>
+        </button>
+      </div>
+
+      <div class="graph-controls">
+        <div class="graph-mode-toggle">
+          <button
+            class={`graph-mode-btn ${!localMode() ? 'active' : ''}`}
+            onClick={() => setLocalMode(false)}
+          >
+            Global
+          </button>
+          <button
+            class={`graph-mode-btn ${localMode() ? 'active' : ''}`}
+            onClick={() => setLocalMode(true)}
+            disabled={!props.currentFile}
+          >
+            Local
+          </button>
+        </div>
+
+        <Show when={localMode()}>
+          <div class="graph-depth-control">
+            <label>Depth:</label>
+            <input
+              type="range"
+              min="1"
+              max="3"
+              value={depth()}
+              onInput={(e) => setDepth(parseInt(e.currentTarget.value))}
+            />
+            <span>{depth()}</span>
+          </div>
+        </Show>
+      </div>
+
+      <div class="graph-stats">
+        <span>{nodeCount()} notes</span>
+        <span>{linkCount()} links</span>
+      </div>
+
+      <Show when={loading()}>
+        <div class="graph-loading">
+          <span>Building graph...</span>
+        </div>
+      </Show>
+
+      <Show when={!props.vaultPath}>
+        <div class="graph-empty">
+          <p>Open a vault to view the graph</p>
+        </div>
+      </Show>
+
+      <Show when={props.vaultPath}>
+        <div class="graph-container" ref={initContainer} />
+      </Show>
+    </div>
+  );
+};
+
+export default GraphView;

--- a/src/styles.css
+++ b/src/styles.css
@@ -647,7 +647,16 @@ body {
 
 .tab-close:hover {
   background: var(--bg-tertiary);
-  color: var(--text-primary);
+}
+
+/* Graph Tab */
+.tab.graph-tab {
+  min-width: auto;
+  gap: 6px;
+}
+
+.tab.graph-tab svg {
+  flex-shrink: 0;
 }
 
 /* Editor Container */
@@ -817,6 +826,135 @@ body {
 .milkdown-editor th { background: var(--bg-secondary); }
 .milkdown-editor img { max-width: 100%; height: auto; }
 .milkdown-editor input[type="checkbox"] { margin-right: 0.5em; }
+
+/* Graph View */
+.graph-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-primary);
+}
+
+.graph-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.graph-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.graph-refresh-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.graph-refresh-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.graph-refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.graph-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.graph-mode-toggle {
+  display: flex;
+  gap: 4px;
+}
+
+.graph-mode-btn {
+  padding: 4px 12px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: all 0.15s ease;
+}
+
+.graph-mode-btn:first-child {
+  border-radius: 4px 0 0 4px;
+}
+
+.graph-mode-btn:last-child {
+  border-radius: 0 4px 4px 0;
+}
+
+.graph-mode-btn.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.graph-mode-btn:hover:not(.active):not(:disabled) {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.graph-mode-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.graph-depth-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.graph-depth-control input[type="range"] {
+  width: 60px;
+  accent-color: var(--accent);
+}
+
+.graph-stats {
+  display: flex;
+  gap: 16px;
+  padding: 6px 16px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  border-bottom: 1px solid var(--border);
+}
+
+.graph-loading,
+.graph-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.graph-container {
+  flex: 1;
+  min-height: 200px;
+}
 
 /* Welcome Screen */
 .welcome-screen {


### PR DESCRIPTION
- Add vis-network library for interactive graph visualization
- Extend note-index.ts with link extraction and graph building
- Create GraphView component with global/local mode toggle
- Support escaped wikilinks (\[\[) in link extraction
- Graph opens as tab in main editor area with toolbar icon
- Nodes sized by incoming link count, click to navigate