### PR TITLE
feat: skills.sh library integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onyx",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Open source knowledge base and note-taking app",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2594,7 +2594,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "onyx"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onyx"
-version = "0.7.0"
+version = "0.8.0"
 description = "Open source knowledge base and note-taking app"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Onyx",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "identifier": "com.onyxnotes.dev",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -1,0 +1,285 @@
+/**
+ * Skills library integration
+ * 
+ * Provides access to:
+ * 1. Curated skills from onyx-skills repo (recommended)
+ * 2. Full skills.sh ecosystem (browse library)
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+// Skills.sh API types
+export interface SkillsShSkill {
+  id: string;
+  name: string;
+  installs: number;
+  topSource: string; // Format: "owner/repo"
+}
+
+export interface SkillsShResponse {
+  skills: SkillsShSkill[];
+  hasMore: boolean;
+}
+
+// Extended skill info for UI
+export interface SkillInfo {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  category: string;
+  dependencies?: string[];
+  files: string[];
+  isCustom?: boolean;
+  // skills.sh specific fields
+  source?: 'onyx' | 'skillssh';
+  installs?: number;
+  topSource?: string; // "owner/repo"
+}
+
+export interface SkillState {
+  enabled: boolean;
+  installed: boolean;
+  downloading: boolean;
+}
+
+// Cache for skills.sh data
+interface SkillsShCache {
+  data: SkillsShSkill[];
+  timestamp: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+let skillsShCache: SkillsShCache | null = null;
+
+/**
+ * Fetch skills leaderboard from skills.sh API
+ * Uses Tauri backend to bypass CORS restrictions
+ * Returns cached data if available and not expired
+ */
+export async function fetchSkillsShLeaderboard(forceRefresh = false): Promise<SkillsShSkill[]> {
+  // Check cache
+  if (!forceRefresh && skillsShCache && Date.now() - skillsShCache.timestamp < CACHE_TTL_MS) {
+    return skillsShCache.data;
+  }
+
+  try {
+    // Use Tauri backend to bypass CORS
+    const responseText = await invoke<string>('fetch_skills_sh');
+    const data: SkillsShResponse = JSON.parse(responseText);
+    
+    // Update cache
+    skillsShCache = {
+      data: data.skills,
+      timestamp: Date.now(),
+    };
+
+    return data.skills;
+  } catch (err) {
+    console.error('Failed to fetch skills.sh leaderboard:', err);
+    // Return cached data if available, even if expired
+    if (skillsShCache) {
+      return skillsShCache.data;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Search/filter skills.sh skills
+ */
+export function searchSkillsSh(skills: SkillsShSkill[], query: string): SkillsShSkill[] {
+  if (!query.trim()) {
+    return skills;
+  }
+
+  const lowerQuery = query.toLowerCase();
+  return skills.filter(skill => 
+    skill.id.toLowerCase().includes(lowerQuery) ||
+    skill.name.toLowerCase().includes(lowerQuery) ||
+    skill.topSource.toLowerCase().includes(lowerQuery)
+  );
+}
+
+/**
+ * Sort skills by different criteria
+ */
+export type SkillsSortOption = 'popular' | 'name' | 'source';
+
+export function sortSkillsSh(skills: SkillsShSkill[], sortBy: SkillsSortOption): SkillsShSkill[] {
+  const sorted = [...skills];
+  switch (sortBy) {
+    case 'popular':
+      return sorted.sort((a, b) => b.installs - a.installs);
+    case 'name':
+      return sorted.sort((a, b) => a.name.localeCompare(b.name));
+    case 'source':
+      return sorted.sort((a, b) => a.topSource.localeCompare(b.topSource));
+    default:
+      return sorted;
+  }
+}
+
+/**
+ * Format install count for display (e.g., 27165 -> "27.2K")
+ */
+export function formatInstallCount(count: number): string {
+  if (count >= 1000000) {
+    return `${(count / 1000000).toFixed(1)}M`;
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K`;
+  }
+  return count.toString();
+}
+
+/**
+ * Get GitHub raw URL for a skill file
+ * skills.sh skills are stored at: https://raw.githubusercontent.com/{owner}/{repo}/main/skills/{skill-id}/SKILL.md
+ */
+export function getSkillFileUrl(topSource: string, skillId: string, fileName: string): string {
+  const [owner, repo] = topSource.split('/');
+  return `https://raw.githubusercontent.com/${owner}/${repo}/main/skills/${skillId}/${fileName}`;
+}
+
+/**
+ * Get GitHub URL for viewing a skill on GitHub
+ */
+export function getSkillGitHubUrl(topSource: string, skillId: string): string {
+  const [owner, repo] = topSource.split('/');
+  return `https://github.com/${owner}/${repo}/tree/main/skills/${skillId}`;
+}
+
+/**
+ * Download and install a skill from skills.sh
+ * Uses Tauri backend to bypass CORS restrictions
+ */
+export async function installSkillFromSkillsSh(skill: SkillsShSkill): Promise<void> {
+  const skillUrl = getSkillFileUrl(skill.topSource, skill.id, 'SKILL.md');
+  
+  try {
+    // Download SKILL.md using Tauri backend to bypass CORS
+    const content = await invoke<string>('fetch_skill_file', { url: skillUrl });
+    
+    // Save the skill file using Tauri backend
+    await invoke('skill_save_file', {
+      skillId: skill.id,
+      fileName: 'SKILL.md',
+      content,
+    });
+  } catch (err) {
+    console.error(`Failed to install skill ${skill.id}:`, err);
+    throw err;
+  }
+}
+
+/**
+ * Check if a skill is installed
+ */
+export async function isSkillInstalled(skillId: string): Promise<boolean> {
+  try {
+    return await invoke<boolean>('skill_is_installed', { skillId });
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Delete an installed skill
+ */
+export async function deleteSkill(skillId: string): Promise<void> {
+  await invoke('skill_delete', { skillId });
+}
+
+/**
+ * Get list of all installed skill IDs
+ */
+export async function getInstalledSkillIds(): Promise<string[]> {
+  return await invoke<string[]>('skill_list_installed');
+}
+
+/**
+ * Read a skill file content
+ */
+export async function readSkillFile(skillId: string, fileName: string): Promise<string> {
+  return await invoke<string>('skill_read_file', { skillId, fileName });
+}
+
+/**
+ * Parse skill name from SKILL.md content
+ */
+export function parseSkillName(content: string, fallbackId: string): string {
+  // Try to find a # heading
+  const headingMatch = content.match(/^#\s+(.+)$/m);
+  if (headingMatch) {
+    return headingMatch[1].trim();
+  }
+  
+  // Try to find a title: metadata
+  const titleMatch = content.match(/^title:\s*(.+)$/mi);
+  if (titleMatch) {
+    return titleMatch[1].trim();
+  }
+  
+  // Use ID as fallback, converting kebab-case to Title Case
+  return fallbackId
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Parse skill description from SKILL.md content
+ */
+export function parseSkillDescription(content: string): string {
+  // Try to find a description: metadata
+  const descMatch = content.match(/^description:\s*(.+)$/mi);
+  if (descMatch) {
+    return descMatch[1].trim();
+  }
+  
+  // Try to find the first paragraph after the heading
+  const lines = content.split('\n');
+  let foundHeading = false;
+  for (const line of lines) {
+    if (line.startsWith('#')) {
+      foundHeading = true;
+      continue;
+    }
+    if (foundHeading && line.trim() && !line.startsWith('#') && !line.startsWith('-') && !line.startsWith('*')) {
+      return line.trim().slice(0, 150);
+    }
+  }
+  
+  return 'A skill for AI agents';
+}
+
+/**
+ * Clear the skills.sh cache
+ */
+export function clearSkillsShCache(): void {
+  skillsShCache = null;
+}
+
+/**
+ * Get unique sources (owners) from skills list for filtering
+ */
+export function getUniqueSources(skills: SkillsShSkill[]): string[] {
+  const sources = new Set<string>();
+  for (const skill of skills) {
+    const [owner] = skill.topSource.split('/');
+    sources.add(owner);
+  }
+  return Array.from(sources).sort();
+}
+
+/**
+ * Filter skills by source/owner
+ */
+export function filterBySource(skills: SkillsShSkill[], source: string): SkillsShSkill[] {
+  if (!source || source === 'all') {
+    return skills;
+  }
+  return skills.filter(skill => skill.topSource.startsWith(source + '/'));
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3506,6 +3506,194 @@ body {
   background: var(--accent-muted);
 }
 
+/* Skills Tabs */
+.skills-tabs {
+  display: flex;
+  gap: 4px;
+  margin: 16px 0;
+  background: var(--bg-primary);
+  padding: 4px;
+  border-radius: 8px;
+}
+
+.skills-tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: all 0.15s ease;
+}
+
+.skills-tab:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.skills-tab.active {
+  background: var(--accent);
+  color: white;
+}
+
+.skills-tab svg {
+  flex-shrink: 0;
+}
+
+/* Skills Search Bar */
+.skills-search-bar {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.skills-search-input {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+}
+
+.skills-search-input:focus-within {
+  border-color: var(--accent);
+}
+
+.skills-search-input input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.skills-search-input input::placeholder {
+  color: var(--text-secondary);
+}
+
+.skills-sort-select {
+  padding: 8px 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  min-width: 140px;
+  /* Fix for dropdown options in dark mode */
+  color-scheme: dark;
+}
+
+[data-theme="light"] .skills-sort-select {
+  color-scheme: light;
+}
+
+.skills-sort-select option {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.skills-sort-select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* Skills.sh Info */
+.skills-sh-info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.skills-sh-info a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.skills-sh-info a:hover {
+  text-decoration: underline;
+}
+
+.skills-count {
+  background: var(--bg-tertiary);
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+/* Skills.sh list specific */
+.skills-sh-list .skill-item {
+  padding: 12px 16px;
+}
+
+.skill-source {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-family: monospace;
+}
+
+.skill-badge.installs {
+  background: rgba(59, 130, 246, 0.2);
+  color: #3b82f6;
+}
+
+.skill-installed-check {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  color: #22c55e;
+}
+
+/* Small setting button variant */
+.setting-button.small {
+  padding: 6px 12px;
+  font-size: 12px;
+  gap: 4px;
+}
+
+/* Skills empty state */
+.skills-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.skills-empty svg {
+  margin-bottom: 16px;
+  opacity: 0.5;
+}
+
+.skills-empty p {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.skills-empty span {
+  font-size: 13px;
+}
+
 /* Custom Modal Dialog */
 .modal-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary

- Adds tabbed interface in Productivity settings with three tabs: **Recommended**, **Browse Library**, and **Installed**
- Integrates with [skills.sh](https://skills.sh) API to browse 500+ community AI skills
- Adds search and sort functionality (by popularity, name, or source)
- Displays install counts with formatted numbers (e.g., 27.2K installs)
- One-click install for any skill from the skills.sh ecosystem

## Technical Changes

- New `src/lib/skills.ts` with API integration, caching (5-min TTL), and utilities
- Added Rust backend commands (`fetch_skills_sh`, `fetch_skill_file`) to bypass CORS
- Updated Settings.tsx with new tabbed UI and state management
- Added CSS styles for tabs, search bar, and dark mode dropdown fix

## Version

Bumps version to **0.8.0**