### PR TITLE
Add OpenAI-compatible custom provider chat panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import CommandPalette from './components/CommandPalette';
 import SearchPanel from './components/SearchPanel';
 import OpenCodePanel from './components/OpenCodePanel';
 import OpenClawChat from './components/OpenClawChat';
+import CustomProviderChat from './components/CustomProviderChat';
 import Settings from './components/Settings';
 import GraphView from './components/GraphView';
 import OutlinePanel from './components/OutlinePanel';
@@ -101,6 +102,10 @@ const App: Component = () => {
   const [showOpenClaw, setShowOpenClaw] = createSignal(false);
   const [openClawWidth, setOpenClawWidth] = createSignal(
     parseInt(localStorage.getItem('openclaw_width') || '500')
+  );
+  const [showCustomProvider, setShowCustomProvider] = createSignal(false);
+  const [customProviderWidth, setCustomProviderWidth] = createSignal(
+    parseInt(localStorage.getItem('custom_provider_width') || '500')
   );
   // Editor view mode: 'live' = rendered markdown, 'source' = raw markdown
   const [editorViewMode, setEditorViewMode] = createSignal<'live' | 'source'>(
@@ -2511,6 +2516,28 @@ const App: Component = () => {
             </svg>
           </button>
         </Show>
+        {/* Custom Provider button - Hidden on mobile */}
+        <Show when={!isMobileApp()}>
+          <button
+            class={`icon-btn custom-provider-icon ${showCustomProvider() ? 'active' : ''}`}
+            onClick={() => {
+              const url = localStorage.getItem('custom_provider_url');
+              if (!url) {
+                setSettingsSection('customprovider');
+                setShowSettings(true);
+              } else {
+                setShowCustomProvider(!showCustomProvider());
+              }
+            }}
+            title="Toggle Custom Provider"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M12 2L2 7l10 5 10-5-10-5z"></path>
+              <path d="M2 17l10 5 10-5"></path>
+              <path d="M2 12l10 5 10-5"></path>
+            </svg>
+          </button>
+        </Show>
         {/* OpenCode button - Hidden on mobile */}
         <Show when={!isMobileApp()}>
           <button
@@ -2852,6 +2879,47 @@ const App: Component = () => {
             </div>
           </Show>
 
+          {/* Custom Provider Panel - Right Side (Desktop only) */}
+          <Show when={showCustomProvider() && !isMobileApp()}>
+            <div
+              class="resize-handle"
+              onMouseDown={(e: MouseEvent) => {
+                e.preventDefault();
+                setIsResizing('terminal');
+                const startX = e.clientX;
+                const startWidth = customProviderWidth();
+                const handleMouseMove = (e: MouseEvent) => {
+                  const delta = startX - e.clientX;
+                  const newWidth = Math.max(300, Math.min(startWidth + delta, window.innerWidth * 0.6));
+                  setCustomProviderWidth(newWidth);
+                };
+                const handleMouseUp = () => {
+                  setIsResizing(null);
+                  localStorage.setItem('custom_provider_width', customProviderWidth().toString());
+                  document.removeEventListener('mousemove', handleMouseMove);
+                  document.removeEventListener('mouseup', handleMouseUp);
+                };
+                document.addEventListener('mousemove', handleMouseMove);
+                document.addEventListener('mouseup', handleMouseUp);
+              }}
+            />
+            <div style={{ width: `${customProviderWidth()}px` }}>
+              <CustomProviderChat
+                onClose={() => setShowCustomProvider(false)}
+                onOpenSettings={() => {
+                  setSettingsSection('customprovider');
+                  setShowSettings(true);
+                }}
+                vaultPath={vaultPath()}
+                currentFile={currentTab() ? { path: currentTab()!.path, content: currentTab()!.content } : null}
+                vaultFiles={noteIndex() ? Array.from(noteIndex()!.allPaths).map(path => ({
+                  path,
+                  name: path.replace(/\\/g, '/').split('/').pop()?.replace(/\.md$/i, '') || path
+                })) : []}
+              />
+            </div>
+          </Show>
+
           {/* OpenCode Panel - Right Side (Desktop only) */}
           <Show when={showTerminal() && !isMobileApp()}>
             <div
@@ -3058,7 +3126,7 @@ const App: Component = () => {
           vaultPath={vaultPath()}
           onSyncComplete={() => refreshSidebar?.()}
           onSyncEnabledChange={(enabled) => setSyncStatus(enabled ? 'idle' : 'off')}
-          initialSection={settingsSection() as 'general' | 'editor' | 'files' | 'appearance' | 'hotkeys' | 'opencode' | 'productivity' | 'sync' | 'nostr' | 'about' | undefined}
+          initialSection={settingsSection() as 'general' | 'editor' | 'files' | 'appearance' | 'hotkeys' | 'opencode' | 'openclaw' | 'customprovider' | 'productivity' | 'sync' | 'nostr' | 'about' | undefined}
         />
       </Show>
 

--- a/src/components/CustomProviderChat.tsx
+++ b/src/components/CustomProviderChat.tsx
@@ -1,0 +1,732 @@
+/**
+ * CustomProviderChat - Chat interface for any OpenAI-compatible API provider
+ * Works with MapleAI Proxy, Ollama, LM Studio, vLLM, or any OpenAI-compatible endpoint.
+ * Communicates via standard OpenAI API (POST /v1/chat/completions)
+ */
+
+import { Component, createSignal, createEffect, onMount, onCleanup, For, Show } from 'solid-js';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { sanitizeUrl } from '../lib/security';
+
+// --- Types ---
+
+interface ChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+interface VaultFile {
+  path: string;
+  name: string;
+}
+
+interface CustomProviderChatProps {
+  onClose: () => void;
+  onOpenSettings: () => void;
+  vaultPath: string | null;
+  currentFile?: { path: string; content: string } | null;
+  vaultFiles?: VaultFile[];
+}
+
+// --- Markdown rendering ---
+
+function markdownToHtml(markdown: string): string {
+  let html = markdown
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_match, lang, code) => {
+    const langClass = lang ? ` class="language-${lang}"` : '';
+    return `<pre><code${langClass}>${code.trim()}</code></pre>`;
+  });
+
+  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+  html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+  html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+  html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+  html = html.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
+  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
+
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, text, url) => {
+    const safeUrl = sanitizeUrl(url);
+    return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+  });
+
+  html = html.replace(/^[\-\*] (.+)$/gm, '<li>$1</li>');
+  html = html.replace(/(<li>.*<\/li>\n?)+/g, '<ul>$&</ul>');
+  html = html.replace(/^\d+\. (.+)$/gm, '<li>$1</li>');
+  html = html.replace(/\n\n+/g, '</p><p>');
+  html = html.replace(/\n/g, '<br>');
+
+  if (!html.startsWith('<')) {
+    html = '<p>' + html + '</p>';
+  }
+
+  html = html.replace(/<p>\s*<\/p>/g, '');
+  html = html.replace(/<p>(<(?:pre|ul|ol|h[1-6]|blockquote))/g, '$1');
+  html = html.replace(/(<\/(?:pre|ul|ol|h[1-6]|blockquote)>)<\/p>/g, '$1');
+
+  return html;
+}
+
+// --- Component ---
+
+const CustomProviderChat: Component<CustomProviderChatProps> = (props) => {
+  const [messages, setMessages] = createSignal<ChatMessage[]>([]);
+  const [inputText, setInputText] = createSignal('');
+  const [isStreaming, setIsStreaming] = createSignal(false);
+  const [streamingContent, setStreamingContent] = createSignal('');
+  const [error, setError] = createSignal<string | null>(null);
+  const [isConfigured, setIsConfigured] = createSignal(false);
+
+  // Model selection
+  const [selectedModel, setSelectedModel] = createSignal<string>(
+    localStorage.getItem('custom_provider_model') || ''
+  );
+  const [showModelDropdown, setShowModelDropdown] = createSignal(false);
+
+  // File context state
+  const [includeContext, setIncludeContext] = createSignal<boolean>(
+    localStorage.getItem('custom_provider_include_context') !== 'false'
+  );
+  const [contextSentForFile, setContextSentForFile] = createSignal<string | null>(null);
+
+  // @file mention state
+  const [mentionedFiles, setMentionedFiles] = createSignal<VaultFile[]>([]);
+  const [showFilePicker, setShowFilePicker] = createSignal(false);
+  const [fileSearchQuery, setFileSearchQuery] = createSignal('');
+  const [selectedFileIndex, setSelectedFileIndex] = createSignal(0);
+
+  let inputRef: HTMLTextAreaElement | undefined;
+  let messagesEndRef: HTMLDivElement | undefined;
+  let streamCleanup: (() => void) | null = null;
+
+  const getConfig = () => {
+    const url = localStorage.getItem('custom_provider_url') || '';
+    const apiKey = localStorage.getItem('custom_provider_api_key') || '';
+    const model = selectedModel();
+    return { url, apiKey, model };
+  };
+
+  const checkConfiguration = () => {
+    const url = localStorage.getItem('custom_provider_url') || '';
+    // API key is optional (Ollama doesn't need one)
+    setIsConfigured(!!url);
+  };
+
+  const getAvailableModels = (): string[] => {
+    try {
+      const stored = localStorage.getItem('custom_provider_models');
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  };
+
+  const hashContent = (content: string): string => {
+    let hash = 0;
+    for (let i = 0; i < content.length; i++) {
+      const char = content.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash;
+    }
+    return hash.toString(16);
+  };
+
+  onMount(() => {
+    checkConfiguration();
+    inputRef?.focus();
+    const handleSettingsChanged = () => {
+      checkConfiguration();
+      // Re-read model if it changed
+      const newModel = localStorage.getItem('custom_provider_model') || '';
+      if (newModel !== selectedModel()) {
+        setSelectedModel(newModel);
+      }
+    };
+    window.addEventListener('custom-provider-settings-changed', handleSettingsChanged);
+    onCleanup(() => {
+      window.removeEventListener('custom-provider-settings-changed', handleSettingsChanged);
+    });
+  });
+
+  const scrollToBottom = () => {
+    requestAnimationFrame(() => {
+      messagesEndRef?.scrollIntoView({ behavior: 'smooth' });
+    });
+  };
+
+  createEffect(() => {
+    messages();
+    streamingContent();
+    scrollToBottom();
+  });
+
+  // --- @file mention helpers ---
+
+  const filteredFiles = () => {
+    const query = fileSearchQuery().toLowerCase();
+    const files = props.vaultFiles || [];
+    if (!query) return files.slice(0, 10);
+    return files
+      .filter(f => f.name.toLowerCase().includes(query) || f.path.toLowerCase().includes(query))
+      .slice(0, 10);
+  };
+
+  const selectFile = (file: VaultFile) => {
+    setMentionedFiles(prev => {
+      if (prev.some(f => f.path === file.path)) return prev;
+      return [...prev, file];
+    });
+    const text = inputText();
+    const atIndex = text.lastIndexOf('@');
+    if (atIndex !== -1) setInputText(text.substring(0, atIndex));
+    setShowFilePicker(false);
+    setFileSearchQuery('');
+    setSelectedFileIndex(0);
+    inputRef?.focus();
+  };
+
+  const removeMentionedFile = (path: string) => {
+    setMentionedFiles(prev => prev.filter(f => f.path !== path));
+  };
+
+  const toggleContext = () => {
+    const newValue = !includeContext();
+    setIncludeContext(newValue);
+    localStorage.setItem('custom_provider_include_context', String(newValue));
+  };
+
+  // --- Model selection ---
+
+  const handleModelChange = (model: string) => {
+    setSelectedModel(model);
+    localStorage.setItem('custom_provider_model', model);
+    setShowModelDropdown(false);
+    window.dispatchEvent(new CustomEvent('custom-provider-settings-changed'));
+  };
+
+  // --- Streaming ---
+
+  const streamCompletion = async (apiMessages: Array<{ role: string; content: string }>): Promise<string> => {
+    const { url, apiKey, model } = getConfig();
+    const baseUrl = url.replace(/\/+$/, '');
+    const fullUrl = `${baseUrl}/v1/chat/completions`;
+    const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    const body = JSON.stringify({
+      model: model || 'default',
+      messages: apiMessages,
+      stream: true,
+    });
+
+    let accumulated = '';
+    let buffer = '';
+
+    return new Promise<string>((resolve, reject) => {
+      let resolved = false;
+
+      listen<string>(`custom-provider-stream-${requestId}`, (event) => {
+        const data = event.payload;
+
+        if (data === '__DONE__') {
+          resolved = true;
+          resolve(accumulated);
+          return;
+        }
+
+        if (data.startsWith('__ERROR__:')) {
+          resolved = true;
+          reject(new Error(data.slice(10)));
+          return;
+        }
+
+        buffer += data;
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed === 'data: [DONE]') continue;
+
+          if (trimmed.startsWith('data: ')) {
+            try {
+              const json = JSON.parse(trimmed.slice(6));
+              const delta = json.choices?.[0]?.delta;
+              if (delta?.content) {
+                accumulated += delta.content;
+                setStreamingContent(accumulated);
+              }
+            } catch {
+              // Skip malformed JSON
+            }
+          }
+        }
+      }).then((unlisten) => {
+        streamCleanup = () => {
+          unlisten();
+          if (!resolved) {
+            resolved = true;
+            resolve(accumulated);
+          }
+          setIsStreaming(false);
+          setStreamingContent('');
+          streamCleanup = null;
+        };
+
+        invoke('custom_provider_stream', {
+          requestId,
+          url: fullUrl,
+          apiKey,
+          body,
+        }).catch((err) => {
+          if (!resolved) {
+            resolved = true;
+            reject(err);
+          }
+        });
+      });
+    });
+  };
+
+  // --- Main send handler ---
+
+  const handleSend = async () => {
+    const text = inputText().trim();
+    if (!text || isStreaming()) return;
+
+    const { url } = getConfig();
+    if (!url) {
+      setError('Custom provider is not configured. Please configure it in Settings.');
+      return;
+    }
+
+    const filesToMention = mentionedFiles();
+
+    // Display text
+    let displayText = text;
+    if (filesToMention.length > 0) {
+      displayText = `[${filesToMention.map(f => f.name).join(', ')}] ${text}`;
+    }
+
+    setMessages(prev => [...prev, { role: 'user', content: displayText }]);
+    setInputText('');
+    setMentionedFiles([]);
+    setError(null);
+    setIsStreaming(true);
+    setStreamingContent('');
+
+    if (inputRef) inputRef.style.height = 'auto';
+
+    // Build the full prompt with context
+    let prompt = text;
+    const file = props.currentFile;
+
+    if (filesToMention.length > 0) {
+      const fileContexts: string[] = [];
+      for (const f of filesToMention) {
+        try {
+          const content = await invoke<string>('read_file', { path: f.path });
+          const truncated = content.length > 50000 ? content.slice(0, 50000) + '\n[...truncated]' : content;
+          fileContexts.push(`=== File: ${f.path} ===\n${truncated}`);
+        } catch (err) {
+          console.error(`Failed to read file ${f.path}:`, err);
+          fileContexts.push(`=== File: ${f.path} ===\n[Error: Could not read file]`);
+        }
+      }
+      prompt = `[Referenced files]\n\n${fileContexts.join('\n\n')}\n\n---\n\n${text}`;
+    } else {
+      const fileKey = file ? `${file.path}:${hashContent(file.content)}` : null;
+      if (file && includeContext() && contextSentForFile() !== fileKey) {
+        const MAX_CONTEXT_LINES = 500;
+        const MAX_CONTEXT_CHARS = 50000;
+        let content = file.content;
+        let truncated = false;
+
+        const lines = content.split('\n');
+        if (lines.length > MAX_CONTEXT_LINES) {
+          content = lines.slice(0, MAX_CONTEXT_LINES).join('\n');
+          truncated = true;
+        }
+        if (content.length > MAX_CONTEXT_CHARS) {
+          content = content.slice(0, MAX_CONTEXT_CHARS);
+          truncated = true;
+        }
+
+        const truncateNote = truncated ? `\n\n[Note: File truncated]` : '';
+        prompt = `[Context: Working on file "${file.path}"]${truncateNote}\n\n${content}\n\n---\n\n${text}`;
+        setContextSentForFile(fileKey);
+      }
+    }
+
+    try {
+      const apiMessages: Array<{ role: string; content: string }> = [];
+
+      // System prompt
+      if (props.vaultPath) {
+        apiMessages.push({
+          role: 'system',
+          content: `You are a helpful AI assistant running inside Onyx, a note-taking app. The user's vault is at: ${props.vaultPath}. Help the user with their questions and tasks.`
+        });
+      }
+
+      // Conversation history (except the last user message we just added)
+      const allMsgs = messages();
+      for (let i = 0; i < allMsgs.length - 1; i++) {
+        apiMessages.push({ role: allMsgs[i].role, content: allMsgs[i].content });
+      }
+
+      // Last user message with full prompt (including context)
+      apiMessages.push({ role: 'user', content: prompt });
+
+      const fullText = await streamCompletion(apiMessages);
+      setStreamingContent('');
+
+      // Add assistant response
+      if (fullText.trim()) {
+        setMessages(prev => [...prev, { role: 'assistant', content: fullText }]);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message || 'Failed to communicate with provider');
+    } finally {
+      setIsStreaming(false);
+      setStreamingContent('');
+      streamCleanup = null;
+    }
+  };
+
+  const handleAbort = () => {
+    if (streamCleanup) streamCleanup();
+  };
+
+  const clearChat = () => {
+    setMessages([]);
+    setStreamingContent('');
+    setError(null);
+    setContextSentForFile(null);
+    setMentionedFiles([]);
+    inputRef?.focus();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (showFilePicker()) {
+      const files = filteredFiles();
+      if (e.key === 'ArrowDown') { e.preventDefault(); setSelectedFileIndex(i => Math.min(i + 1, files.length - 1)); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); setSelectedFileIndex(i => Math.max(i - 1, 0)); return; }
+      if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); const s = files[selectedFileIndex()]; if (s) selectFile(s); return; }
+      if (e.key === 'Escape') { e.preventDefault(); setShowFilePicker(false); setFileSearchQuery(''); return; }
+    }
+    if (showModelDropdown() && e.key === 'Escape') { e.preventDefault(); setShowModelDropdown(false); return; }
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend(); }
+    if (e.key === 'Escape' && isStreaming()) { handleAbort(); }
+  };
+
+  const handleInput = (e: Event) => {
+    const target = e.target as HTMLTextAreaElement;
+    const value = target.value;
+    setInputText(value);
+
+    const cursorPos = target.selectionStart || 0;
+    const textBeforeCursor = value.substring(0, cursorPos);
+    const atIndex = textBeforeCursor.lastIndexOf('@');
+
+    if (atIndex !== -1 && (atIndex === 0 || textBeforeCursor[atIndex - 1] === ' ' || textBeforeCursor[atIndex - 1] === '\n')) {
+      const afterAt = textBeforeCursor.substring(atIndex + 1);
+      if (!afterAt.includes(' ') && !afterAt.includes('\n')) {
+        setFileSearchQuery(afterAt);
+        setShowFilePicker(true);
+        setSelectedFileIndex(0);
+      } else {
+        setShowFilePicker(false);
+      }
+    } else {
+      setShowFilePicker(false);
+    }
+
+    target.style.height = 'auto';
+    target.style.height = Math.min(target.scrollHeight, 150) + 'px';
+  };
+
+  const ProviderIcon = () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M12 2L2 7l10 5 10-5-10-5z"></path>
+      <path d="M2 17l10 5 10-5"></path>
+      <path d="M2 12l10 5 10-5"></path>
+    </svg>
+  );
+
+  const providerName = () => {
+    return localStorage.getItem('custom_provider_name') || 'Custom Provider';
+  };
+
+  // --- Render ---
+
+  return (
+    <div class="custom-provider-panel">
+      {/* Header */}
+      <div class="custom-provider-panel-header">
+        <div class="custom-provider-panel-title">
+          <ProviderIcon />
+          <span>{providerName()}</span>
+        </div>
+        <div class="custom-provider-panel-actions">
+          <Show when={messages().length > 0}>
+            <button class="custom-provider-action-btn" onClick={clearChat} title="Clear chat">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="3 6 5 6 21 6"></polyline>
+                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+              </svg>
+            </button>
+          </Show>
+          <button class="custom-provider-action-btn" onClick={props.onOpenSettings} title="Provider Settings">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="3"></circle>
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+            </svg>
+          </button>
+          <button class="custom-provider-action-btn" onClick={props.onClose} title="Close">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Not configured */}
+      <Show when={!isConfigured()}>
+        <div class="custom-provider-not-configured">
+          <div class="custom-provider-setup-icon"><ProviderIcon /></div>
+          <h3>Provider Not Configured</h3>
+          <p>Set up your OpenAI-compatible provider URL to start chatting. Works with MapleAI Proxy, Ollama, LM Studio, and more.</p>
+          <button class="setting-button primary" onClick={props.onOpenSettings}>Configure Provider</button>
+        </div>
+      </Show>
+
+      {/* Chat */}
+      <Show when={isConfigured()}>
+        <div class="custom-provider-messages">
+          <Show when={messages().length === 0 && !isStreaming()}>
+            <div class="custom-provider-welcome">
+              <div class="custom-provider-welcome-icon"><ProviderIcon /></div>
+              <h3>{providerName()}</h3>
+              <p>Ask anything. Type @ to reference files from your vault.</p>
+              <Show when={selectedModel()}>
+                <div class="custom-provider-welcome-model">Model: {selectedModel()}</div>
+              </Show>
+            </div>
+          </Show>
+
+          <For each={messages()}>
+            {(message) => (
+              <div class={`custom-provider-message ${message.role}`}>
+                <Show when={message.role === 'assistant'}>
+                  <div class="custom-provider-message-avatar"><ProviderIcon /></div>
+                </Show>
+                <div class="custom-provider-message-content">
+                  <Show when={message.role === 'assistant'} fallback={
+                    <div class="custom-provider-message-text">{message.content}</div>
+                  }>
+                    <div class="custom-provider-message-text markdown" innerHTML={markdownToHtml(message.content)} />
+                  </Show>
+                </div>
+              </div>
+            )}
+          </For>
+
+          {/* Streaming message */}
+          <Show when={isStreaming() && streamingContent()}>
+            <div class="custom-provider-message assistant">
+              <div class="custom-provider-message-avatar"><ProviderIcon /></div>
+              <div class="custom-provider-message-content">
+                <div class="custom-provider-message-text markdown" innerHTML={markdownToHtml(streamingContent())} />
+              </div>
+            </div>
+          </Show>
+
+          {/* Typing indicator */}
+          <Show when={isStreaming() && !streamingContent()}>
+            <div class="custom-provider-message assistant">
+              <div class="custom-provider-message-avatar"><ProviderIcon /></div>
+              <div class="custom-provider-message-content">
+                <div class="custom-provider-typing">
+                  <span></span><span></span><span></span>
+                </div>
+              </div>
+            </div>
+          </Show>
+
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Error banner */}
+        <Show when={error()}>
+          <div class="custom-provider-error-banner">
+            <span>{error()}</span>
+            <button onClick={() => setError(null)}>x</button>
+          </div>
+        </Show>
+
+        {/* Input */}
+        <div class="custom-provider-input-container">
+          <div class="custom-provider-input-toolbar">
+            <Show when={props.currentFile}>
+              <button
+                class={`chat-context-toggle ${includeContext() ? 'active' : ''}`}
+                onClick={toggleContext}
+                title={includeContext() ? 'Document context included' : 'Document context not included'}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                  <polyline points="14 2 14 8 20 8"></polyline>
+                </svg>
+                <span>{props.currentFile!.path.replace(/\\/g, '/').split('/').pop()}</span>
+                <Show when={includeContext()}>
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                  </svg>
+                </Show>
+              </button>
+            </Show>
+            <Show when={messages().length > 0}>
+              <button class="chat-clear-btn" onClick={clearChat} title="Clear chat">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="3 6 5 6 21 6"></polyline>
+                  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                </svg>
+                <span>Clear</span>
+              </button>
+            </Show>
+
+            {/* Model selector */}
+            <div class="custom-provider-model-selector" style={{ position: 'relative' }}>
+              <button
+                class="chat-model-indicator"
+                onClick={() => setShowModelDropdown(!showModelDropdown())}
+                title="Select model"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M12 2L2 7l10 5 10-5-10-5z"></path>
+                  <path d="M2 17l10 5 10-5"></path>
+                  <path d="M2 12l10 5 10-5"></path>
+                </svg>
+                <span>{selectedModel() || 'Select model'}</span>
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="6 9 12 15 18 9"></polyline>
+                </svg>
+              </button>
+              <Show when={showModelDropdown()}>
+                <div class="custom-provider-model-dropdown">
+                  <For each={getAvailableModels()}>
+                    {(model) => (
+                      <button
+                        class={`custom-provider-model-option ${model === selectedModel() ? 'active' : ''}`}
+                        onClick={() => handleModelChange(model)}
+                      >
+                        {model}
+                      </button>
+                    )}
+                  </For>
+                  <Show when={getAvailableModels().length === 0}>
+                    <div class="custom-provider-model-empty">
+                      No models found. Check provider settings.
+                    </div>
+                  </Show>
+                </div>
+              </Show>
+            </div>
+          </div>
+
+          {/* Mentioned files */}
+          <Show when={mentionedFiles().length > 0}>
+            <div class="chat-mentioned-files">
+              <For each={mentionedFiles()}>
+                {(file) => (
+                  <div class="mentioned-file-chip">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                      <polyline points="14 2 14 8 20 8"></polyline>
+                    </svg>
+                    <span>{file.name}</span>
+                    <button class="remove-file-btn" onClick={() => removeMentionedFile(file.path)} title="Remove file">
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                      </svg>
+                    </button>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+
+          <div class="chat-input-wrapper">
+            <Show when={showFilePicker() && filteredFiles().length > 0}>
+              <div class="chat-file-picker">
+                <div class="file-picker-header">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="11" cy="11" r="8"></circle>
+                    <path d="m21 21-4.35-4.35"></path>
+                  </svg>
+                  <span>Select a file to reference</span>
+                </div>
+                <For each={filteredFiles()}>
+                  {(file, index) => (
+                    <div
+                      class={`file-picker-item ${index() === selectedFileIndex() ? 'selected' : ''}`}
+                      onClick={() => selectFile(file)}
+                      onMouseEnter={() => setSelectedFileIndex(index())}
+                    >
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                        <polyline points="14 2 14 8 20 8"></polyline>
+                      </svg>
+                      <span class="file-name">{file.name}</span>
+                      <span class="file-path">{file.path.replace(/\\/g, '/').split('/').slice(-2, -1)[0] || ''}</span>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
+
+            <textarea
+              ref={inputRef}
+              class="chat-input"
+              placeholder={`Ask ${providerName()} anything... (type @ to reference files)`}
+              value={inputText()}
+              onInput={handleInput}
+              onKeyDown={handleKeyDown}
+              disabled={isStreaming()}
+              rows={1}
+            />
+            <Show when={isStreaming()} fallback={
+              <button
+                class="chat-send-btn"
+                onClick={handleSend}
+                disabled={!inputText().trim() || isStreaming()}
+                title="Send (Enter)"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="22" y1="2" x2="11" y2="13"></line>
+                  <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+                </svg>
+              </button>
+            }>
+              <button class="chat-abort-btn" onClick={handleAbort} title="Stop (Escape)">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <rect x="6" y="6" width="12" height="12"></rect>
+                </svg>
+              </button>
+            </Show>
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default CustomProviderChat;

--- a/src/styles.css
+++ b/src/styles.css
@@ -9205,3 +9205,429 @@ body {
 .app.mobile .openclaw-icon {
   display: none;
 }
+
+/* =====================================================
+   Custom Provider Chat Panel
+   ===================================================== */
+
+.custom-provider-panel {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+}
+
+.custom-provider-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.custom-provider-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.custom-provider-panel-title svg {
+  color: var(--accent);
+}
+
+.custom-provider-panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.custom-provider-action-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.custom-provider-action-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+/* Not configured state */
+.custom-provider-not-configured {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  text-align: center;
+  gap: 12px;
+}
+
+.custom-provider-setup-icon {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-muted, rgba(100, 100, 255, 0.1));
+  border-radius: 12px;
+  color: var(--accent);
+}
+
+.custom-provider-setup-icon svg {
+  width: 28px;
+  height: 28px;
+}
+
+.custom-provider-not-configured h3 {
+  font-size: 16px;
+  color: var(--text-primary);
+  margin: 0;
+  font-weight: 600;
+}
+
+.custom-provider-not-configured p {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0;
+  max-width: 280px;
+  line-height: 1.5;
+}
+
+/* Messages */
+.custom-provider-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.custom-provider-welcome {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 8px;
+}
+
+.custom-provider-welcome-icon {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-muted, rgba(100, 100, 255, 0.1));
+  border-radius: 10px;
+  color: var(--accent);
+}
+
+.custom-provider-welcome-icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.custom-provider-welcome h3 {
+  font-size: 15px;
+  color: var(--text-primary);
+  margin: 0;
+  font-weight: 600;
+}
+
+.custom-provider-welcome p {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin: 0;
+  max-width: 240px;
+  line-height: 1.5;
+}
+
+.custom-provider-welcome-model {
+  font-size: 11px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  padding: 3px 10px;
+  border-radius: 10px;
+  margin-top: 4px;
+}
+
+/* Message bubbles */
+.custom-provider-message {
+  display: flex;
+  gap: 10px;
+  max-width: 100%;
+}
+
+.custom-provider-message.user {
+  flex-direction: row-reverse;
+}
+
+.custom-provider-message-avatar {
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-muted, rgba(100, 100, 255, 0.1));
+  border-radius: 50%;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.custom-provider-message-avatar svg {
+  width: 16px;
+  height: 16px;
+}
+
+.custom-provider-message-content {
+  max-width: 85%;
+}
+
+.custom-provider-message.user .custom-provider-message-content {
+  background: var(--accent);
+  color: #fff;
+  border-radius: 14px 14px 4px 14px;
+  padding: 8px 14px;
+}
+
+.custom-provider-message.assistant .custom-provider-message-content {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-radius: 14px 14px 14px 4px;
+  padding: 8px 14px;
+}
+
+.custom-provider-message-text {
+  font-size: 13px;
+  line-height: 1.6;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.custom-provider-message-text.markdown pre {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  overflow-x: auto;
+  margin: 8px 0;
+  font-size: 12px;
+}
+
+.custom-provider-message-text.markdown code {
+  background: var(--bg-primary);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 12px;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+}
+
+.custom-provider-message-text.markdown pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+
+.custom-provider-message-text.markdown h1,
+.custom-provider-message-text.markdown h2,
+.custom-provider-message-text.markdown h3 {
+  margin: 8px 0 4px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.custom-provider-message-text.markdown ul,
+.custom-provider-message-text.markdown ol {
+  margin: 4px 0;
+  padding-left: 20px;
+}
+
+.custom-provider-message-text.markdown li {
+  margin: 2px 0;
+}
+
+.custom-provider-message-text.markdown a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.custom-provider-message-text.markdown strong {
+  font-weight: 600;
+}
+
+/* Typing indicator */
+.custom-provider-typing {
+  display: flex;
+  gap: 4px;
+  padding: 4px 0;
+}
+
+.custom-provider-typing span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  animation: custom-provider-bounce 1.4s ease-in-out infinite;
+}
+
+.custom-provider-typing span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.custom-provider-typing span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes custom-provider-bounce {
+  0%, 80%, 100% { transform: translateY(0); opacity: 0.4; }
+  40% { transform: translateY(-6px); opacity: 1; }
+}
+
+/* Error banner */
+.custom-provider-error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: rgba(231, 76, 60, 0.1);
+  color: #e74c3c;
+  font-size: 12px;
+  border-top: 1px solid rgba(231, 76, 60, 0.2);
+}
+
+.custom-provider-error-banner button {
+  background: none;
+  border: none;
+  color: #e74c3c;
+  cursor: pointer;
+  padding: 2px 6px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* Input area */
+.custom-provider-input-container {
+  border-top: 1px solid var(--border);
+  background: var(--bg-secondary);
+  padding: 8px 12px;
+  flex-shrink: 0;
+}
+
+.custom-provider-input-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 0 6px;
+  font-size: 11px;
+}
+
+/* Model selector dropdown */
+.custom-provider-model-selector {
+  margin-left: auto;
+}
+
+.custom-provider-model-dropdown {
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  margin-bottom: 4px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  min-width: 200px;
+  max-width: 320px;
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 100;
+}
+
+.custom-provider-model-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.custom-provider-model-option:hover {
+  background: var(--bg-tertiary);
+}
+
+.custom-provider-model-option.active {
+  background: var(--accent-muted, rgba(100, 100, 255, 0.1));
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.custom-provider-model-empty {
+  padding: 12px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+/* Settings quick setup guides */
+.custom-provider-guides {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.custom-provider-guide {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+}
+
+.custom-provider-guide strong {
+  color: var(--text-primary);
+  font-size: 13px;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.custom-provider-guide p {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin: 2px 0;
+  line-height: 1.5;
+}
+
+.custom-provider-guide code {
+  font-size: 11px;
+  background: var(--bg-primary);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+}
+
+/* Hide Custom Provider button on mobile */
+.app.mobile .custom-provider-icon {
+  display: none;
+}


### PR DESCRIPTION
## Summary

Adds a new "Custom Provider" chat panel that connects to any OpenAI-compatible API, making it easy to use local proxies and inference servers directly from Onyx.

- Adds three new Tauri proxy commands (`custom_provider_request`, `custom_provider_stream`, `custom_provider_list_models`) that bypass CORS for local servers
- Adds `CustomProviderChat` component with streaming responses, @file mentions, document context toggle, and dynamic model selection
- Adds a "Custom Provider" section in Settings with URL, optional API key, model fetching from `/v1/models`, and connection testing
- Includes quick-setup reference cards for MapleAI Proxy, Ollama, and LM Studio

## Tested With

- MapleAI Proxy with API key auth
- Ollama without auth

## Screenshots

<img width="928" height="621" alt="Custom Provider Settings" src="https://github.com/user-attachments/assets/2a333ba8-c0dc-428f-9f6e-15c70cbdee5f" />

Settings panel provides URL, API key, model fetch, and connection test — matching the existing OpenCode/OpenClaw settings layout. Chat panel appears alongside existing AI panels in the icon bar.

<img width="1211" height="737" alt="Custom Provider Pane" src="https://github.com/user-attachments/assets/d38600c6-949a-4bd8-b87d-a8878265d6f6" />
