### PR TITLE
Add zapstore.yaml for Zapstore distribution

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,0 +1,26 @@
+name: Onyx
+summary: Private, encrypted note-taking app with AI productivity tools
+description: |
+  Onyx is a private, encrypted note-taking application built on the Nostr
+  protocol with integrated AI productivity tools. Your notes are encrypted
+  with your keys — no server, no company, no third party can read your content.
+
+  Features:
+  - End-to-end encrypted notes using Nostr
+  - AI-powered productivity (cloud and local model support)
+  - Cross-platform (Android, Desktop, macOS)
+  - Self-custodial — you own your data
+license: MIT
+repository: https://github.com/derekross/onyx
+website: https://onyxnotes.dev
+assets:
+  - app-universal-release.apk
+metadata_sources:
+  - github
+tags:
+  - nostr
+  - notes
+  - encryption
+  - privacy
+  - ai
+  - productivity


### PR DESCRIPTION
## What

Adds a `zapstore.yaml` configuration file to enable publishing Onyx to [Zapstore](https://zapstore.dev), the permissionless Nostr-based app store.

## Configuration

- **Assets:** Pulls `app-universal-release.apk` from GitHub releases
- **Metadata:** Enriched from GitHub (description, topics, license, README)
- **Tags:** nostr, notes, encryption, privacy, ai, productivity

## How to publish

Once merged, publish to Zapstore using [zsp](https://github.com/zapstore/zsp):

```bash
zsp publish zapstore.yaml
```

Or use the interactive wizard:
```bash
zsp publish --wizard
```

## References

- [zsp documentation](https://github.com/zapstore/zsp)
- [Zapstore publishing docs](https://zapstore.dev/docs/publish)
- Format follows conventions used by [Amethyst](https://github.com/vitorpamplona/amethyst/blob/main/zapstore.yaml) and other Nostr apps