### PR TITLE
feat: editor improvements — keymap, heading fold, link reveal, wikilink cursor awareness, editor header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "onyx",
       "version": "0.13.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
@@ -48,6 +47,7 @@
         "nostr-tools": "^2.19.4",
         "qrcode": "^1.5.4",
         "qrcode.react": "^4.2.0",
+        "remark-wiki-link": "^2.0.1",
         "solid-js": "^1.9.10",
         "uuid": "^13.0.0",
         "vis-data": "^8.0.3",
@@ -59,7 +59,6 @@
         "@tauri-apps/cli": "^2.9.6",
         "@types/jszip": "^3.4.0",
         "@types/uuid": "^10.0.0",
-        "patch-package": "^8.0.1",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",
         "vite-plugin-solid": "^2.11.10"
@@ -281,6 +280,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2336,13 +2344,6 @@
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "license": "MIT"
     },
-    "node_modules/@yarnpkg/lockfile": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/adler-32": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
@@ -2480,19 +2481,6 @@
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
       "license": "MIT"
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -2525,56 +2513,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -2630,23 +2568,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -2657,20 +2578,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
+    "node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/cliui": {
@@ -2779,21 +2704,6 @@
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2845,24 +2755,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2906,21 +2798,6 @@
         "underscore": "^1.13.1"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
@@ -2945,39 +2822,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -3068,19 +2912,6 @@
         }
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3094,16 +2925,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/find-yarn-workspace-root": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "micromatch": "^4.0.2"
-      }
-    },
     "node_modules/frac": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
@@ -3111,21 +2932,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/fsevents": {
@@ -3141,16 +2947,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
@@ -3172,114 +2968,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -3299,20 +2987,38 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
+    "node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
       "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -3324,14 +3030,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+    "node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-plain-obj": {
@@ -3359,31 +3065,11 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3405,33 +3091,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-stable-stringify": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
-      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "isarray": "^2.0.5",
-        "jsonify": "^0.0.1",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/json-stable-stringify/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3443,29 +3102,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "dev": true,
-      "license": "Public Domain",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jszip": {
@@ -3486,16 +3122,6 @@
       "integrity": "sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==",
       "license": "(Apache-2.0 OR MIT)",
       "peer": true
-    },
-    "node_modules/klaw-sync": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.11"
-      }
     },
     "node_modules/lie": {
       "version": "3.3.0",
@@ -3587,16 +3213,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -3803,6 +3419,70 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-wiki-link": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-wiki-link/-/mdast-util-wiki-link-0.1.2.tgz",
+      "integrity": "sha512-DTcDyOxKDo3pB3fc0zQlD8myfQjYkW4hazUKI9PUyhtoj9JBeHC2eIdlVXmaT22bZkFAVU2d47B6y2jVKGoUQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "mdast-util-to-markdown": "^0.6.5"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/mdast-util-to-markdown": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.0.0",
+        "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/zwitch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/merge-anything": {
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.7.tgz",
@@ -4007,6 +3687,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-wiki-link": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/micromark-extension-wiki-link/-/micromark-extension-wiki-link-0.0.4.tgz",
+      "integrity": "sha512-dJc8AfnoU8BHkN+7fWZvIS20SMsMS1ZlxQUn6We67MqeKbOiEDZV5eEvCpwqGBijbJbxX3Kxz879L4K9HIiOvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -4382,43 +4071,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4501,33 +4153,6 @@
       "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
       "license": "MIT"
     },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/option": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
@@ -4582,6 +4207,34 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -4593,49 +4246,6 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/patch-package": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
-      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^4.1.2",
-        "ci-info": "^3.7.0",
-        "cross-spawn": "^7.0.3",
-        "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^10.0.0",
-        "json-stable-stringify": "^1.0.2",
-        "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.6",
-        "open": "^7.4.2",
-        "semver": "^7.5.3",
-        "slash": "^2.0.0",
-        "tmp": "^0.2.4",
-        "yaml": "^2.2.2"
-      },
-      "bin": {
-        "patch-package": "index.js"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">5"
-      }
-    },
-    "node_modules/patch-package/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/path-exists": {
@@ -4654,16 +4264,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/picocolors": {
@@ -5013,6 +4613,26 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-wiki-link": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remark-wiki-link/-/remark-wiki-link-2.0.1.tgz",
+      "integrity": "sha512-F8Eut1E7GWfFm4ZDTI6/4ejeZEHZgnVk6E933Yqd/ssYsc4AyI32aGakxwsGcEzbbE7dkWi1EfLlGAdGgOZOsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.4.4",
+        "mdast-util-wiki-link": "^0.1.2",
+        "micromark-extension-wiki-link": "^0.0.4"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5122,62 +4742,11 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
-    },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/solid-js": {
       "version": "1.9.11",
@@ -5274,19 +4843,6 @@
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5302,29 +4858,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/trough": {
@@ -5441,16 +4974,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -5713,22 +5236,6 @@
       "integrity": "sha512-YKPDfxlK5qOheLZ2bTIiktZO1bpfGdNCPJmTEaPW7G9UXI1GKjDdeacOrsULUS000OPNxDVOyAuKLuIWPqWM0Q==",
       "license": "MIT"
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
@@ -5830,22 +5337,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "15.4.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3030,7 +3030,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "onyx"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,6 +133,12 @@ const App: Component = () => {
   const [editorViewMode, setEditorViewMode] = createSignal<'live' | 'source'>(
     (localStorage.getItem('editor_view_mode') as 'live' | 'source') || 'live'
   );
+  // Reader mode: locks editing
+  const [readerMode, setReaderMode] = createSignal(false);
+  // Editor header three-dot menu
+  const [editorMenuOpen, setEditorMenuOpen] = createSignal(false);
+  // Ref for the editor header title input (for programmatic focus)
+  let editorHeaderTitleRef: HTMLInputElement | undefined;
   // Flag to prevent settings save effect from running before initial load completes
   const [settingsLoaded, setSettingsLoaded] = createSignal(false);
   const [showSettings, setShowSettings] = createSignal(false);
@@ -1582,6 +1588,101 @@ const App: Component = () => {
     await syncPreferencesToNostr(updated, savedSearches());
   };
 
+  // Editor header actions
+  const editorHeaderRename = async (newName: string) => {
+    const tab = currentTab();
+    if (!tab?.path || !vaultPath()) return;
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+
+    const oldPath = tab.path;
+    const parentPath = oldPath.replace(/\\/g, '/').split('/').slice(0, -1).join('/');
+    const newPath = `${parentPath}/${trimmed}.md`;
+    if (newPath === oldPath) return;
+
+    try {
+      await invoke('rename_file', { oldPath, newPath, vaultPath: vaultPath() });
+      // Update tab
+      setTabs(tabs().map(t => t.path === oldPath ? { ...t, path: newPath, name: trimmed } : t));
+      handleFileMoved(oldPath, newPath);
+    } catch (err) {
+      console.error('Failed to rename:', err);
+    }
+  };
+
+  const editorHeaderMakeCopy = async () => {
+    const tab = currentTab();
+    if (!tab?.path || !vaultPath()) return;
+    const fileName = tab.path.replace(/\\/g, '/').split('/').pop() || '';
+    const parentPath = tab.path.replace(/\\/g, '/').split('/').slice(0, -1).join('/');
+    const ext = fileName.includes('.') ? fileName.substring(fileName.lastIndexOf('.')) : '';
+    const baseName = ext ? fileName.substring(0, fileName.lastIndexOf('.')) : fileName;
+    const copyPath = `${parentPath}/${baseName} copy${ext}`;
+    try {
+      await invoke('copy_file', { source: tab.path, dest: copyPath, vaultPath: vaultPath() });
+      refreshSidebar?.();
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+    setEditorMenuOpen(false);
+  };
+
+  const editorHeaderMoveTo = async () => {
+    const tab = currentTab();
+    if (!tab?.path || !vaultPath()) return;
+    try {
+      const { open } = await import('@tauri-apps/plugin-dialog');
+      const selected = await open({ directory: true, multiple: false, title: 'Move to...' });
+      if (selected && typeof selected === 'string') {
+        const fileName = tab.path.replace(/\\/g, '/').split('/').pop() || '';
+        const destPath = `${selected}/${fileName}`;
+        await invoke('rename_file', { oldPath: tab.path, newPath: destPath, vaultPath: vaultPath() });
+        setTabs(tabs().map(t => t.path === tab.path ? { ...t, path: destPath } : t));
+        handleFileMoved(tab.path, destPath);
+        refreshSidebar?.();
+      }
+    } catch (err) {
+      console.error('Failed to move:', err);
+    }
+    setEditorMenuOpen(false);
+  };
+
+  const editorHeaderCopyPath = async () => {
+    const tab = currentTab();
+    if (tab?.path) {
+      try { await navigator.clipboard.writeText(tab.path); } catch {}
+    }
+    setEditorMenuOpen(false);
+  };
+
+  const editorHeaderOpenInDefaultApp = async () => {
+    const tab = currentTab();
+    if (tab?.path) {
+      try { await invoke('open_in_default_app', { path: tab.path }); } catch {}
+    }
+    setEditorMenuOpen(false);
+  };
+
+  const editorHeaderShowInFolder = async () => {
+    const tab = currentTab();
+    if (tab?.path) {
+      try { await invoke('show_in_folder', { path: tab.path }); } catch {}
+    }
+    setEditorMenuOpen(false);
+  };
+
+  const editorHeaderDelete = async () => {
+    const tab = currentTab();
+    if (!tab?.path || !vaultPath()) return;
+    try {
+      await invoke('delete_file', { path: tab.path, vaultPath: vaultPath() });
+      handleFileDeleted(tab.path);
+    } catch (err) {
+      console.error('Failed to delete:', err);
+    }
+    setEditorMenuOpen(false);
+  };
+
   const toggleSavedSearch = async (query: string) => {
     const current = savedSearches();
     let updated: string[];
@@ -2720,6 +2821,113 @@ const App: Component = () => {
         <div class="content-area">
           {/* Editor, Viewer, or Graph View */}
           <div class="editor-area">
+            {/* Editor Header: editable file name + reader mode + three-dot menu */}
+            <Show when={currentTab()?.path && !showGraphView()}>
+              <div class="editor-header">
+                <div class="editor-header-title-area">
+                  <input
+                    class="editor-header-title-input"
+                    value={currentTab()!.name}
+                    ref={(el) => { editorHeaderTitleRef = el; }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        editorHeaderRename(e.currentTarget.value);
+                        e.currentTarget.blur();
+                      }
+                      if (e.key === 'Escape') {
+                        e.currentTarget.value = currentTab()!.name;
+                        e.currentTarget.blur();
+                      }
+                    }}
+                    onBlur={(e) => editorHeaderRename(e.currentTarget.value)}
+                    spellcheck={false}
+                  />
+                </div>
+                <div class="editor-header-actions">
+                  {/* Reader mode toggle */}
+                  <button
+                    class={`editor-header-btn ${readerMode() ? 'active' : ''}`}
+                    onClick={() => setReaderMode(!readerMode())}
+                    title={readerMode() ? 'Exit reader mode' : 'Enter reader mode'}
+                  >
+                    <Show when={readerMode()} fallback={
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path>
+                        <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path>
+                      </svg>
+                    }>
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M12 20h9"></path>
+                        <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path>
+                      </svg>
+                    </Show>
+                  </button>
+                  {/* Three-dot menu */}
+                  <div class="editor-menu-container">
+                    <button
+                      class="editor-header-btn"
+                      onClick={() => setEditorMenuOpen(!editorMenuOpen())}
+                      title="More options"
+                    >
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                        <circle cx="12" cy="5" r="1.5"></circle>
+                        <circle cx="12" cy="12" r="1.5"></circle>
+                        <circle cx="12" cy="19" r="1.5"></circle>
+                      </svg>
+                    </button>
+                    <Show when={editorMenuOpen()}>
+                      <div class="editor-menu-backdrop" onClick={() => setEditorMenuOpen(false)} />
+                      <div class="editor-menu">
+                        <div class="context-menu-item" onClick={() => { const tab = currentTab(); if (tab) openFile(tab.path); setEditorMenuOpen(false); }}>
+                          Open in new tab
+                        </div>
+                        <div class="context-menu-divider" />
+                        <div class="context-menu-item" onClick={editorHeaderMakeCopy}>
+                          Make a copy
+                        </div>
+                        <div class="context-menu-item" onClick={editorHeaderMoveTo}>
+                          Move file to...
+                        </div>
+                        <div class="context-menu-item" onClick={() => { const tab = currentTab(); if (tab) toggleBookmark(tab.path); setEditorMenuOpen(false); }}>
+                          {currentTab()?.path && bookmarks().includes(currentTab()!.path) ? 'Remove bookmark' : 'Bookmark'}
+                        </div>
+                        <div class="context-menu-item" onClick={() => { const tab = currentTab(); if (tab) handleFileInfo(tab.path); setEditorMenuOpen(false); }}>
+                          File info...
+                        </div>
+                        <Show when={currentTab()?.path?.endsWith('.md')}>
+                          <div class="context-menu-divider" />
+                          <div class="context-menu-label">Nostr</div>
+                          <div class="context-menu-item" onClick={() => { const tab = currentTab(); if (tab) handleShareFile(tab.path, tab.content); setEditorMenuOpen(false); }}>
+                            Share with user...
+                          </div>
+                          <div class="context-menu-item" onClick={() => { const tab = currentTab(); if (tab) handlePostToNostr(tab.path, tab.content, tab.name); setEditorMenuOpen(false); }}>
+                            Publish as article...
+                          </div>
+                        </Show>
+                        <div class="context-menu-divider" />
+                        <div class="context-menu-item" onClick={editorHeaderCopyPath}>
+                          Copy path
+                        </div>
+                        <div class="context-menu-item" onClick={editorHeaderOpenInDefaultApp}>
+                          Open in default app
+                        </div>
+                        <div class="context-menu-item" onClick={editorHeaderShowInFolder}>
+                          Show in system explorer
+                        </div>
+                        <div class="context-menu-divider" />
+                        <div class="context-menu-item" onClick={() => { setEditorMenuOpen(false); editorHeaderTitleRef?.focus(); editorHeaderTitleRef?.select(); }}>
+                          Rename
+                        </div>
+                        <div class="context-menu-item danger" onClick={editorHeaderDelete}>
+                          Delete
+                        </div>
+                      </div>
+                    </Show>
+                  </div>
+                </div>
+              </div>
+            </Show>
+
             <Show when={currentTab()?.fileType && currentTab()!.fileType !== 'markdown'} fallback={
               <Show when={showGraphView()} fallback={
                 <Editor
@@ -2742,6 +2950,7 @@ const App: Component = () => {
                   scrollToHeadingText={scrollToHeadingText()}
                   scrollToBlockId={scrollToBlockId()}
                   viewMode={editorViewMode()}
+                  readOnly={readerMode()}
                   onFilesUploaded={async () => {
                     // Rebuild asset index after files are uploaded
                     if (vaultPath()) {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,5 +1,5 @@
 import { Component, onCleanup, Show, createSignal, createEffect, on } from 'solid-js';
-import { Editor, rootCtx, defaultValueCtx, editorViewCtx, parserCtx } from '@milkdown/core';
+import { Editor, rootCtx, defaultValueCtx, editorViewCtx, editorViewOptionsCtx, parserCtx } from '@milkdown/core';
 import { commonmark, remarkPreserveEmptyLinePlugin } from '@milkdown/preset-commonmark';
 import { gfm } from '@milkdown/preset-gfm';
 import { nord } from '@milkdown/theme-nord';
@@ -30,6 +30,9 @@ import {
 import { highlightPlugin } from '../lib/editor/highlight-plugin';
 import { commentPlugin } from '../lib/editor/comment-plugin';
 import { calloutPlugin } from '../lib/editor/callout-plugin';
+import { headingFoldPlugin } from '../lib/editor/heading-fold-plugin';
+import { linkInputRulePlugin, linkClickPlugin, linkRevealPlugin } from '../lib/editor/link-input-rule-plugin';
+import { keymapPlugin } from '../lib/editor/keymap-plugin';
 import { AssetIndex } from '../lib/editor/asset-index';
 import {
   vaultUploadPlugin,
@@ -69,6 +72,8 @@ interface EditorProps {
   onFilesUploaded?: () => void;
   // View mode: 'live' = rendered markdown, 'source' = raw markdown
   viewMode?: 'live' | 'source';
+  // Reader mode: locks editing (read-only)
+  readOnly?: boolean;
 }
 
 const MilkdownEditor: Component<EditorProps> = (props) => {
@@ -140,6 +145,14 @@ const MilkdownEditor: Component<EditorProps> = (props) => {
         ctx.set(defaultValueCtx, initialContent);
       })
       .config(nord)
+      // Set initial editable state based on readOnly prop
+      .config((ctx) => {
+        ctx.update(editorViewOptionsCtx, (prev) => ({
+          ...prev,
+          editable: () => !props.readOnly,
+        }));
+      })
+      .use(keymapPlugin)
       .use(customCommonmark)
       .use(gfm)
       .use(embedSchema)
@@ -158,6 +171,10 @@ const MilkdownEditor: Component<EditorProps> = (props) => {
       .use(highlightPlugin)
       .use(commentPlugin)
       .use(calloutPlugin)
+      .use(headingFoldPlugin)
+      .use(linkInputRulePlugin)
+      .use(linkClickPlugin)
+      .use(linkRevealPlugin)
       // Configure listener after the plugin is loaded
       .config((ctx) => {
         ctx.get(listenerCtx).markdownUpdated((ctx, markdown, _prevMarkdown) => {
@@ -576,6 +593,22 @@ const MilkdownEditor: Component<EditorProps> = (props) => {
           } catch (e) {
             console.error('Failed to scroll to block:', e);
           }
+        }
+      }
+    )
+  );
+
+  // Toggle ProseMirror editability when readOnly prop changes
+  createEffect(
+    on(
+      () => props.readOnly,
+      (readOnly) => {
+        if (!editorInstance?.ctx) return;
+        try {
+          const view = editorInstance.ctx.get(editorViewCtx);
+          view.setProps({ editable: () => !readOnly });
+        } catch (e) {
+          // View may not be ready yet, ignore
         }
       }
     )

--- a/src/lib/editor/heading-fold-plugin.ts
+++ b/src/lib/editor/heading-fold-plugin.ts
@@ -1,0 +1,205 @@
+import { $prose } from '@milkdown/utils';
+import { Plugin, PluginKey, Transaction } from '@milkdown/prose/state';
+import { Decoration, DecorationSet, EditorView } from '@milkdown/prose/view';
+
+export const headingFoldPluginKey = new PluginKey<HeadingFoldState>('headingFold');
+
+// Meta key used to toggle fold state via transactions
+const TOGGLE_FOLD_META = 'toggleHeadingFold';
+
+interface HeadingFoldState {
+  // Set of folded heading positions (document positions).
+  // We track by heading text+level as a stable key since positions shift on edits.
+  foldedHeadings: Set<string>;
+  decorations: DecorationSet;
+}
+
+interface HeadingLocation {
+  pos: number;
+  endPos: number; // pos + node.nodeSize
+  level: number;
+  text: string;
+  key: string; // stable key: `${level}:${text}`
+}
+
+/** Find all headings in the document with their positions. */
+function findHeadings(doc: any): HeadingLocation[] {
+  const headings: HeadingLocation[] = [];
+  // Track occurrence count per level:text to disambiguate duplicate headings
+  const occurrences = new Map<string, number>();
+
+  doc.descendants((node: any, pos: number) => {
+    if (node.type.name === 'heading' && node.attrs.level) {
+      const baseKey = `${node.attrs.level}:${node.textContent}`;
+      const count = (occurrences.get(baseKey) || 0) + 1;
+      occurrences.set(baseKey, count);
+
+      headings.push({
+        pos,
+        endPos: pos + node.nodeSize,
+        level: node.attrs.level,
+        text: node.textContent,
+        key: count > 1 ? `${baseKey}#${count}` : baseKey,
+      });
+    }
+  });
+  return headings;
+}
+
+/**
+ * For a given heading at index `idx`, find the range of nodes that should be
+ * hidden when folded. This is everything after the heading until the next
+ * heading of equal or higher (lower number) level, or end of document.
+ */
+function getFoldRange(
+  headings: HeadingLocation[],
+  idx: number,
+  doc: any
+): { from: number; to: number } | null {
+  const heading = headings[idx];
+  const from = heading.endPos; // Start hiding after the heading node
+
+  // Find next heading of equal or higher level
+  let to = doc.content.size;
+  for (let i = idx + 1; i < headings.length; i++) {
+    if (headings[i].level <= heading.level) {
+      to = headings[i].pos;
+      break;
+    }
+  }
+
+  // Nothing to fold if there's no content between headings
+  if (from >= to) return null;
+  return { from, to };
+}
+
+/** Create all decorations: chevrons on every heading + hide decorations for folded content. */
+function buildDecorations(
+  doc: any,
+  foldedHeadings: Set<string>
+): DecorationSet {
+  const headings = findHeadings(doc);
+  const decorations: Decoration[] = [];
+
+  for (let i = 0; i < headings.length; i++) {
+    const h = headings[i];
+    const isFolded = foldedHeadings.has(h.key);
+
+    // Check if there's foldable content below this heading
+    const foldRange = getFoldRange(headings, i, doc);
+    const hasFoldableContent = foldRange !== null;
+
+    // Add chevron widget decoration at the start of the heading
+    if (hasFoldableContent) {
+      const chevron = document.createElement('span');
+      chevron.className = `heading-fold-chevron${isFolded ? ' folded' : ''}`;
+      chevron.setAttribute('data-heading-key', h.key);
+      chevron.setAttribute('aria-label', isFolded ? 'Expand section' : 'Collapse section');
+      chevron.setAttribute('role', 'button');
+      chevron.textContent = isFolded ? '\u25B6' : '\u25BC'; // ▶ or ▼
+      chevron.contentEditable = 'false';
+
+      // Place inside the heading node (pos + 1 enters the heading's content)
+      // with side: -1 to appear before the text content.
+      // Include fold state in the key so ProseMirror creates a new DOM element
+      // when the state changes (otherwise it reuses the old element).
+      decorations.push(
+        Decoration.widget(h.pos + 1, chevron, {
+          side: -1,
+          key: `chevron-${h.key}-${isFolded ? 'f' : 'o'}`,
+        })
+      );
+    }
+
+    // If folded, hide all nodes in the fold range
+    if (isFolded && foldRange) {
+      // Walk through top-level nodes in the range and add node decorations to hide them
+      doc.nodesBetween(foldRange.from, foldRange.to, (node: any, pos: number) => {
+        // Only decorate top-level nodes (direct children of doc, depth === 0)
+        if (pos >= foldRange.from && pos < foldRange.to) {
+          const resolved = doc.resolve(pos);
+          if (resolved.depth === 0) {
+            decorations.push(
+              Decoration.node(pos, pos + node.nodeSize, {
+                class: 'heading-folded-content',
+              })
+            );
+            return false; // Don't descend into children
+          }
+        }
+        return true;
+      });
+    }
+  }
+
+  return DecorationSet.create(doc, decorations);
+}
+
+export const headingFoldPlugin = $prose(() => {
+  return new Plugin({
+    key: headingFoldPluginKey,
+
+    state: {
+      init(_, { doc }): HeadingFoldState {
+        const foldedHeadings = new Set<string>();
+        return {
+          foldedHeadings,
+          decorations: buildDecorations(doc, foldedHeadings),
+        };
+      },
+
+      apply(tr: Transaction, oldState: HeadingFoldState): HeadingFoldState {
+        const toggleKey = tr.getMeta(TOGGLE_FOLD_META) as string | undefined;
+
+        if (toggleKey) {
+          // Toggle fold state for the heading
+          const newFolded = new Set(oldState.foldedHeadings);
+          if (newFolded.has(toggleKey)) {
+            newFolded.delete(toggleKey);
+          } else {
+            newFolded.add(toggleKey);
+          }
+          return {
+            foldedHeadings: newFolded,
+            decorations: buildDecorations(tr.doc, newFolded),
+          };
+        }
+
+        if (tr.docChanged) {
+          // Rebuild decorations with current fold state
+          return {
+            foldedHeadings: oldState.foldedHeadings,
+            decorations: buildDecorations(tr.doc, oldState.foldedHeadings),
+          };
+        }
+
+        // No changes
+        return oldState;
+      },
+    },
+
+    props: {
+      decorations(state) {
+        const pluginState = this.getState(state);
+        return pluginState?.decorations || DecorationSet.empty;
+      },
+
+      handleDOMEvents: {
+        click(view: EditorView, event: Event) {
+          const target = event.target as HTMLElement;
+          if (target.classList.contains('heading-fold-chevron')) {
+            event.preventDefault();
+            event.stopPropagation();
+            const key = target.getAttribute('data-heading-key');
+            if (key) {
+              const tr = view.state.tr.setMeta(TOGGLE_FOLD_META, key);
+              view.dispatch(tr);
+            }
+            return true;
+          }
+          return false;
+        },
+      },
+    },
+  });
+});

--- a/src/lib/editor/keymap-plugin.ts
+++ b/src/lib/editor/keymap-plugin.ts
@@ -1,0 +1,227 @@
+/**
+ * Custom Keymap Plugin for the Milkdown/ProseMirror editor.
+ *
+ * Fixes and features:
+ * 1. Enter inside/after wikilink: moves cursor past ]] before splitting
+ * 2. Enter on empty list item: exits the list (lifts the item out)
+ * 3. Enter on task list item: creates a new unchecked task item
+ * 4. Shift+Enter: inserts a hard break (soft line break) for indented
+ *    continuation blocks within list items (like Obsidian)
+ */
+
+import { $prose } from '@milkdown/utils';
+import { Plugin, PluginKey, TextSelection } from '@milkdown/prose/state';
+import { keymap } from '@milkdown/prose/keymap';
+
+export const keymapPluginKey = new PluginKey('custom-keymap');
+
+// Same regex used in wikilink-plugin.ts
+const WIKILINK_REGEX = /(?<!!)\[\[([^\]#|^]*)?(?:#([^\]|^]+?))?(?:\^([^\]|]+))?(?:#\^([^\]|]+))?(?:\|([^\]]+))?\]\]/g;
+
+/**
+ * Check if the cursor is positioned inside a wikilink (between [[ and ]]).
+ * If so, returns the position just after the closing ]].
+ * Returns null if cursor is not inside a wikilink.
+ */
+function getWikilinkEndIfCursorInside(state: any): number | null {
+  const { selection, doc } = state;
+  if (!selection.empty) return null;
+
+  const pos = selection.from;
+
+  // Get the text node the cursor is in
+  const $pos = doc.resolve(pos);
+  const parent = $pos.parent;
+  if (!parent.isTextblock) return null;
+
+  // Get the full text of the parent text block and the offset within it
+  const parentOffset = $pos.parentOffset;
+  const fullText = parent.textContent;
+
+  // Find all wikilinks in this text block
+  WIKILINK_REGEX.lastIndex = 0;
+  let match;
+  while ((match = WIKILINK_REGEX.exec(fullText)) !== null) {
+    const linkStart = match.index;
+    const linkEnd = linkStart + match[0].length;
+
+    // Check if cursor is inside this wikilink (between [[ and ]])
+    if (parentOffset > linkStart && parentOffset < linkEnd) {
+      // Cursor is inside the wikilink. Return the absolute position of
+      // the character just after the closing ]]
+      const blockStart = $pos.start();
+      return blockStart + linkEnd;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find the list_item node at the current cursor position.
+ * Returns { node, pos, depth } or null.
+ */
+function findListItemAtCursor(state: any): { node: any; pos: number; depth: number } | null {
+  const { $from } = state.selection;
+  for (let d = $from.depth; d > 0; d--) {
+    const node = $from.node(d);
+    if (node.type.name === 'list_item') {
+      return { node, pos: $from.before(d), depth: d };
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if a list item is "empty" -- contains only whitespace or nothing.
+ */
+function isListItemEmpty(node: any): boolean {
+  let textContent = '';
+  node.descendants((child: any) => {
+    if (child.isText) {
+      textContent += child.text;
+    }
+  });
+  return textContent.trim().length === 0;
+}
+
+/**
+ * Check if the current list item is a task list item.
+ */
+function isTaskListItem(node: any): boolean {
+  return node.attrs.checked !== undefined && node.attrs.checked !== null;
+}
+
+/**
+ * Handle Enter key in the editor.
+ */
+function handleEnter(state: any, dispatch: any): boolean {
+  if (!dispatch) return false;
+
+  const { selection, schema } = state;
+  if (!selection.empty) return false;
+
+  // 1. If cursor is inside a wikilink, move it past ]] and then split
+  const wikilinkEnd = getWikilinkEndIfCursorInside(state);
+  if (wikilinkEnd !== null) {
+    const { tr, doc } = state;
+    // Move cursor to just after ]]
+    const $newPos = doc.resolve(wikilinkEnd);
+    tr.setSelection(TextSelection.near($newPos));
+    // Now split the block at the new position
+    const splitPos = tr.selection.from;
+    tr.split(splitPos);
+    dispatch(tr.scrollIntoView());
+    return true;
+  }
+
+  // 2. Handle list item behavior
+  const listItem = findListItemAtCursor(state);
+  if (listItem) {
+    const { node, pos, depth } = listItem;
+
+    // 2a. Empty list item: Exit the list (lift the item out)
+    if (isListItemEmpty(node)) {
+      const { $from } = selection;
+      const listDepth = depth - 1;
+      if (listDepth >= 0) {
+        const listNode = $from.node(listDepth);
+        if (listNode.type.name === 'bullet_list' || listNode.type.name === 'ordered_list') {
+          // If this is the only item in the list, replace the list with an empty paragraph
+          if (listNode.childCount === 1) {
+            const listPos = $from.before(listDepth);
+            const { tr } = state;
+            tr.replaceWith(listPos, listPos + listNode.nodeSize, schema.nodes.paragraph.create());
+            tr.setSelection(TextSelection.near(tr.doc.resolve(listPos + 1)));
+            dispatch(tr.scrollIntoView());
+            return true;
+          }
+
+          // If it's the last item, delete it and place cursor after the list
+          const isLast = $from.index(listDepth) === listNode.childCount - 1;
+          if (isLast) {
+            const { tr } = state;
+            tr.delete(pos, pos + node.nodeSize);
+            // Insert a paragraph after the list
+            const listPos = $from.before(listDepth);
+            const updatedList = tr.doc.nodeAt(listPos);
+            if (updatedList) {
+              const listEnd = listPos + updatedList.nodeSize;
+              tr.insert(listEnd, schema.nodes.paragraph.create());
+              tr.setSelection(TextSelection.near(tr.doc.resolve(listEnd + 1)));
+            }
+            dispatch(tr.scrollIntoView());
+            return true;
+          }
+
+          // Empty item in the middle -- delete it and place cursor at start of next item
+          const { tr } = state;
+          tr.delete(pos, pos + node.nodeSize);
+          tr.setSelection(TextSelection.near(tr.doc.resolve(pos)));
+          dispatch(tr.scrollIntoView());
+          return true;
+        }
+      }
+    }
+
+    // 2b. Non-empty task list item at end of content: create new unchecked task
+    if (isTaskListItem(node)) {
+      const endOfItem = pos + node.nodeSize;
+      const cursorAtEnd = selection.from >= endOfItem - 2;
+
+      if (cursorAtEnd) {
+        const { tr } = state;
+        const newItem = schema.nodes.list_item.create(
+          { checked: false, spread: false },
+          schema.nodes.paragraph.create()
+        );
+        tr.insert(endOfItem, newItem);
+        tr.setSelection(TextSelection.near(tr.doc.resolve(endOfItem + 2)));
+        dispatch(tr.scrollIntoView());
+        return true;
+      }
+      // Cursor in the middle of task text -- let default split handle it
+      return false;
+    }
+
+    // 2c. Regular list items: let ProseMirror's default splitListItem handle it
+    return false;
+  }
+
+  // 3. Everything else: let ProseMirror handle it
+  return false;
+}
+
+/**
+ * Handle Shift+Enter: insert a hard break (soft line break).
+ * Creates an indented continuation block within list items,
+ * matching Obsidian's Shift+Enter behavior.
+ */
+function handleShiftEnter(state: any, dispatch: any): boolean {
+  if (!dispatch) return false;
+
+  const { schema } = state;
+
+  // Check if hard_break node type exists in the schema
+  const hardBreak = schema.nodes.hard_break || schema.nodes.hardbreak;
+  if (!hardBreak) return false;
+
+  const { tr } = state;
+  const { from, to } = state.selection;
+
+  // Delete any selected content first
+  if (from !== to) {
+    tr.deleteSelection();
+  }
+
+  tr.replaceSelectionWith(hardBreak.create());
+  dispatch(tr.scrollIntoView());
+  return true;
+}
+
+export const keymapPlugin = $prose(() => {
+  return keymap({
+    'Enter': handleEnter,
+    'Shift-Enter': handleShiftEnter,
+  }) as unknown as Plugin;
+});

--- a/src/lib/editor/link-input-rule-plugin.ts
+++ b/src/lib/editor/link-input-rule-plugin.ts
@@ -1,0 +1,365 @@
+/**
+ * Link Behavior Plugin
+ *
+ * Three features:
+ * 1. Input Rule: Converts typed [text](url) into a proper link mark in
+ *    real-time. When the user types the closing ")" of a markdown link,
+ *    this plugin detects the pattern and replaces the raw text with a
+ *    linked text node. Cursor lands AFTER the link so it doesn't
+ *    immediately trigger expansion.
+ *
+ * 2. Click Handler: Opens external links on Ctrl/Cmd+click (like Obsidian).
+ *
+ * 3. Link Reveal: When the cursor enters a rendered link, the link mark
+ *    is expanded into raw [text](url) text so both text and URL are
+ *    editable. When cursor leaves, it collapses back into a link mark.
+ */
+
+import { $prose } from '@milkdown/utils';
+import { Plugin, PluginKey, TextSelection } from '@milkdown/prose/state';
+import { Decoration, DecorationSet, EditorView } from '@milkdown/prose/view';
+import { InputRule, inputRules } from '@milkdown/prose/inputrules';
+
+export const linkInputRulePluginKey = new PluginKey('linkInputRule');
+const linkClickPluginKey = new PluginKey('linkClick');
+const linkRevealPluginKey = new PluginKey('linkReveal');
+
+// Matches [text](url) at the end of input (for the input rule).
+const LINK_INPUT_REGEX = /\[([^\[\]]+)\]\(([^)]+)\)$/;
+
+// Matches [text](url) anywhere (for collapsing expanded links).
+const LINK_FULL_REGEX = /\[([^\[\]]+)\]\(([^)]+)\)/;
+
+/**
+ * Input rule: converts typed [text](url) to a link mark.
+ * Places cursor AFTER the link to avoid triggering immediate expansion.
+ */
+const linkRule = new InputRule(LINK_INPUT_REGEX, (state, match, start, end) => {
+  const linkMark = state.schema.marks.link;
+  if (!linkMark) return null;
+
+  const [, text, url] = match;
+  if (!text || !url) return null;
+
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) return null;
+
+  const mark = linkMark.create({ href: trimmedUrl, title: null });
+  const textNode = state.schema.text(text, [mark]);
+  // Add a zero-width space after the link so the cursor lands outside the mark
+  const spacer = state.schema.text(' ');
+  const tr = state.tr.replaceWith(start, end, [textNode, spacer]);
+  // Place cursor after the space (outside the link mark)
+  tr.setSelection(TextSelection.create(tr.doc, start + text.length + 1));
+  return tr;
+});
+
+/** Open a URL in the system browser */
+function openExternal(url: string) {
+  try {
+    import('@tauri-apps/plugin-opener').then(({ openUrl }) => {
+      openUrl(url);
+    }).catch(() => {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    });
+  } catch {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+}
+
+/** The input rule plugin */
+export const linkInputRulePlugin = $prose(() => {
+  return inputRules({ rules: [linkRule] }) as unknown as Plugin;
+});
+
+/** The click handler plugin: opens links on Ctrl/Cmd+click */
+export const linkClickPlugin = $prose(() => {
+  return new Plugin({
+    key: linkClickPluginKey,
+    props: {
+      handleClick(_view: EditorView, _pos: number, event: MouseEvent) {
+        if (!event.ctrlKey && !event.metaKey) return false;
+
+        const target = event.target as HTMLElement;
+        const anchor = target.closest('a');
+        if (!anchor) return false;
+
+        const href = anchor.getAttribute('href');
+        if (!href) return false;
+
+        if (/^(https?:|mailto:)/.test(href)) {
+          event.preventDefault();
+          openExternal(href);
+          return true;
+        }
+
+        return false;
+      },
+    },
+  });
+});
+
+// --- Link Reveal Plugin ---
+
+/** Info about a link mark range in the document */
+interface LinkRange {
+  from: number;
+  to: number;
+  href: string;
+  text: string;
+}
+
+/** Info about an expanded (raw text) link in the document */
+interface ExpandedLink {
+  from: number;
+  to: number;
+}
+
+/**
+ * Find all link mark ranges in the document.
+ */
+function findLinkRanges(doc: any, linkMarkType: any): LinkRange[] {
+  const ranges: LinkRange[] = [];
+  doc.descendants((node: any, pos: number) => {
+    if (!node.isText) return;
+    for (const mark of node.marks) {
+      if (mark.type === linkMarkType) {
+        const from = pos;
+        const to = pos + node.nodeSize;
+        const href = mark.attrs.href || '';
+        const text = node.text || '';
+
+        const last = ranges[ranges.length - 1];
+        if (last && last.to === from && last.href === href) {
+          last.to = to;
+          last.text += text;
+        } else {
+          ranges.push({ from, to, href, text });
+        }
+      }
+    }
+  });
+  return ranges;
+}
+
+/** Find which link range the cursor is inside */
+function findCursorLink(ranges: LinkRange[], cursorPos: number): LinkRange | null {
+  for (const r of ranges) {
+    if (cursorPos >= r.from && cursorPos <= r.to) return r;
+  }
+  return null;
+}
+
+interface LinkRevealState {
+  expanded: ExpandedLink | null;
+  decorations: DecorationSet;
+}
+
+function buildExpandedDecorations(doc: any, expanded: ExpandedLink | null): DecorationSet {
+  if (!expanded) return DecorationSet.empty;
+  try {
+    const deco = Decoration.inline(expanded.from, expanded.to, {
+      class: 'link-expanded',
+    });
+    return DecorationSet.create(doc, [deco]);
+  } catch {
+    return DecorationSet.empty;
+  }
+}
+
+/** Link reveal plugin */
+export const linkRevealPlugin = $prose(() => {
+  let linkMarkType: any = null;
+
+  // Robust guard: tracks whether we are in the middle of an expand/collapse.
+  // Using a counter so nested calls (shouldn't happen but safety) work.
+  let suppressCount = 0;
+
+  // After an expand, we need to suppress exactly one update cycle
+  // to prevent the view.update from seeing a stale state.
+  let justExpanded = false;
+  let justCollapsed = false;
+
+  return new Plugin({
+    key: linkRevealPluginKey,
+
+    state: {
+      init(_, { schema }): LinkRevealState {
+        linkMarkType = schema.marks.link;
+        return { expanded: null, decorations: DecorationSet.empty };
+      },
+
+      apply(tr, oldState: LinkRevealState, _oldEditorState, newEditorState): LinkRevealState {
+        if (!linkMarkType) return oldState;
+
+        // Check for explicit state updates from expand/collapse
+        const meta = tr.getMeta(linkRevealPluginKey);
+        if (meta !== undefined) {
+          const expanded = meta.expanded as ExpandedLink | null;
+          return {
+            expanded,
+            decorations: buildExpandedDecorations(newEditorState.doc, expanded),
+          };
+        }
+
+        // Map expanded positions through document changes
+        let expanded = oldState.expanded;
+        if (expanded && tr.docChanged) {
+          const newFrom = tr.mapping.map(expanded.from, 1);
+          const newTo = tr.mapping.map(expanded.to, -1);
+          if (newFrom < newTo) {
+            expanded = { from: newFrom, to: newTo };
+          } else {
+            expanded = null;
+          }
+        }
+
+        if (expanded !== oldState.expanded || tr.docChanged) {
+          return {
+            expanded,
+            decorations: buildExpandedDecorations(newEditorState.doc, expanded),
+          };
+        }
+
+        return oldState;
+      },
+    },
+
+    props: {
+      decorations(state) {
+        const pluginState = this.getState(state) as LinkRevealState | undefined;
+        return pluginState?.decorations || DecorationSet.empty;
+      },
+    },
+
+    view() {
+      return {
+        update(view: EditorView) {
+          if (!linkMarkType || suppressCount > 0) return;
+
+          // Skip the update cycle right after expand/collapse to let state settle
+          if (justExpanded) {
+            justExpanded = false;
+            return;
+          }
+          if (justCollapsed) {
+            justCollapsed = false;
+            return;
+          }
+
+          const state = view.state;
+          const pluginState = linkRevealPluginKey.getState(state) as LinkRevealState | undefined;
+          if (!pluginState) return;
+
+          const { head } = state.selection;
+          const expanded = pluginState.expanded;
+
+          if (expanded) {
+            // We have an expanded link — check if cursor left it
+            if (head < expanded.from || head > expanded.to) {
+              collapseLink(view, expanded);
+            }
+            return;
+          }
+
+          // No expanded link — check if cursor entered a link mark
+          const linkRanges = findLinkRanges(state.doc, linkMarkType);
+          const activeLink = findCursorLink(linkRanges, head);
+          if (activeLink) {
+            expandLink(view, activeLink, head);
+          }
+        },
+      };
+    },
+  });
+
+  function expandLink(view: EditorView, link: LinkRange, cursorPos: number) {
+    suppressCount++;
+    justExpanded = true;
+    try {
+      const { state } = view;
+      const rawText = `[${link.text}](${link.href})`;
+      const textNode = state.schema.text(rawText);
+
+      let tr = state.tr.replaceWith(link.from, link.to, textNode);
+
+      // Also strip any link mark from the newly inserted text
+      // (ProseMirror may inherit marks from surrounding context)
+      tr = tr.removeMark(link.from, link.from + rawText.length, linkMarkType);
+
+      // Cursor position: offset into link text + 1 for the opening `[`
+      const offsetInLinkText = cursorPos - link.from;
+      const newCursorPos = Math.min(
+        link.from + 1 + offsetInLinkText,
+        link.from + rawText.length
+      );
+      tr = tr.setSelection(TextSelection.create(tr.doc, newCursorPos));
+
+      const expanded: ExpandedLink = {
+        from: link.from,
+        to: link.from + rawText.length,
+      };
+      tr = tr.setMeta(linkRevealPluginKey, { expanded });
+      // Prevent the markdown listener from re-serializing during this edit
+      tr = tr.setMeta('addToHistory', true);
+
+      view.dispatch(tr);
+    } finally {
+      suppressCount--;
+    }
+  }
+
+  function collapseLink(view: EditorView, expanded: ExpandedLink) {
+    suppressCount++;
+    justCollapsed = true;
+    try {
+      const { state } = view;
+
+      // Clamp positions to doc boundaries
+      const from = Math.max(0, expanded.from);
+      const to = Math.min(expanded.to, state.doc.content.size);
+      if (from >= to) {
+        // Range is invalid, just clear the state
+        const tr = state.tr.setMeta(linkRevealPluginKey, { expanded: null });
+        view.dispatch(tr);
+        return;
+      }
+
+      const currentText = state.doc.textBetween(from, to);
+      const match = LINK_FULL_REGEX.exec(currentText);
+
+      let tr = state.tr;
+
+      if (match && match[1] && match[2]?.trim()) {
+        const linkText = match[1];
+        const linkUrl = match[2].trim();
+
+        const mark = linkMarkType.create({ href: linkUrl, title: null });
+        const textNode = state.schema.text(linkText, [mark]);
+
+        const matchStart = from + match.index;
+        const matchEnd = matchStart + match[0].length;
+        tr = tr.replaceWith(matchStart, matchEnd, textNode);
+      }
+      // If no match, the user broke the syntax — leave as plain text
+
+      tr = tr.setMeta(linkRevealPluginKey, { expanded: null });
+
+      // Map the current cursor position through the collapse replacement.
+      // The replaceWith shrank the document (e.g., `[link](url)` → `link`),
+      // so positions after the replacement shifted upward. We must map
+      // state.selection.head through tr.mapping to get the correct position.
+      const mappedCursor = tr.mapping.map(state.selection.head);
+      const safeCursor = Math.min(mappedCursor, tr.doc.content.size);
+      try {
+        tr = tr.setSelection(TextSelection.create(tr.doc, safeCursor));
+      } catch {
+        tr = tr.setSelection(TextSelection.create(tr.doc, 0));
+      }
+
+      view.dispatch(tr);
+    } finally {
+      suppressCount--;
+    }
+  }
+});

--- a/src/lib/editor/wikilink-plugin.ts
+++ b/src/lib/editor/wikilink-plugin.ts
@@ -12,6 +12,9 @@
  * - [[#heading]] - Link to heading in current note
  * - [[^blockid]] - Link to block in current note
  * - [[note#^blockid]] - Alternative block reference syntax
+ *
+ * Cursor awareness: When the cursor is inside a wikilink, the [[ and ]]
+ * brackets are revealed so the user can edit the full link syntax.
  */
 
 import { $prose } from '@milkdown/utils';
@@ -97,8 +100,18 @@ function navigateToAnchor(view: EditorView, heading: string | null, blockId: str
   return false;
 }
 
-// Find all wikilinks in the document and create decorations
-function findWikilinks(doc: any): DecorationSet {
+/** Wikilink range info for cursor awareness */
+interface WikilinkRange {
+  fullStart: number;
+  fullEnd: number;
+}
+
+/**
+ * Find all wikilinks in the document and create decorations.
+ * When cursorPos is inside a wikilink, that wikilink's brackets are
+ * shown (not hidden) so the user can edit the full syntax.
+ */
+function findWikilinks(doc: any, cursorPos: number | null): DecorationSet {
   const decorations: Decoration[] = [];
 
   doc.descendants((node: any, pos: number) => {
@@ -144,29 +157,86 @@ function findWikilinks(doc: any): DecorationSet {
                    currentNoteIndex.byRelativePath.has(target.replace(/\.md$/i, ''));
         }
 
-        // Decoration for opening [[
-        decorations.push(Decoration.inline(openBracketStart, openBracketEnd, {
-          class: 'wikilink-bracket',
-        }));
+        // Check if cursor is inside this wikilink (between [[ and ]])
+        const cursorInside = cursorPos !== null &&
+          cursorPos >= openBracketStart && cursorPos <= closeBracketEnd;
 
-        // Decoration for the link content
-        decorations.push(Decoration.inline(contentStart, contentEnd, {
-          class: exists ? 'wikilink' : 'wikilink broken',
-          'data-target': target,
-          'data-heading': heading || '',
-          'data-block': blockId || '',
-          'data-alias': alias || '',
-        }));
+        if (cursorInside) {
+          // Cursor is inside: show brackets with a subtle style
+          decorations.push(Decoration.inline(openBracketStart, openBracketEnd, {
+            class: 'wikilink-bracket-visible',
+          }));
 
-        // Decoration for closing ]]
-        decorations.push(Decoration.inline(closeBracketStart, closeBracketEnd, {
-          class: 'wikilink-bracket',
-        }));
+          // Show the full raw content (target|alias, #heading, etc.) with editing style
+          decorations.push(Decoration.inline(contentStart, contentEnd, {
+            class: (exists ? 'wikilink' : 'wikilink broken') + ' wikilink-editing',
+            'data-target': target,
+            'data-heading': heading || '',
+            'data-block': blockId || '',
+            'data-alias': alias || '',
+          }));
+
+          decorations.push(Decoration.inline(closeBracketStart, closeBracketEnd, {
+            class: 'wikilink-bracket-visible',
+          }));
+        } else {
+          // Cursor is outside: hide brackets, show styled link
+          decorations.push(Decoration.inline(openBracketStart, openBracketEnd, {
+            class: 'wikilink-bracket',
+          }));
+
+          decorations.push(Decoration.inline(contentStart, contentEnd, {
+            class: exists ? 'wikilink' : 'wikilink broken',
+            'data-target': target,
+            'data-heading': heading || '',
+            'data-block': blockId || '',
+            'data-alias': alias || '',
+          }));
+
+          decorations.push(Decoration.inline(closeBracketStart, closeBracketEnd, {
+            class: 'wikilink-bracket',
+          }));
+        }
       }
     }
   });
 
   return DecorationSet.create(doc, decorations);
+}
+
+/**
+ * Find all wikilink ranges in the document (for efficient cursor-in-wikilink checks).
+ */
+function findWikilinkRanges(doc: any): WikilinkRange[] {
+  const ranges: WikilinkRange[] = [];
+  doc.descendants((node: any, pos: number) => {
+    if (node.isText) {
+      const text = node.text || '';
+      WIKILINK_REGEX.lastIndex = 0;
+      let match;
+      while ((match = WIKILINK_REGEX.exec(text)) !== null) {
+        const fullStart = pos + match.index;
+        const fullEnd = fullStart + match[0].length;
+        ranges.push({ fullStart, fullEnd });
+      }
+    }
+  });
+  return ranges;
+}
+
+/** Find which wikilink range the cursor is inside, or null */
+function findCursorWikilink(ranges: WikilinkRange[], cursorPos: number): WikilinkRange | null {
+  for (const r of ranges) {
+    if (cursorPos >= r.fullStart && cursorPos <= r.fullEnd) return r;
+  }
+  return null;
+}
+
+interface WikilinkPluginState {
+  decorations: DecorationSet;
+  ranges: WikilinkRange[];
+  // The wikilink range the cursor is currently inside (null if outside all)
+  activeWikilink: WikilinkRange | null;
 }
 
 // Create the ProseMirror plugin for wikilinks
@@ -175,21 +245,52 @@ export const wikilinkPlugin = $prose(() => {
     key: wikilinkPluginKey,
 
     state: {
-      init(_, { doc }) {
-        return findWikilinks(doc);
+      init(_, { doc }): WikilinkPluginState {
+        const ranges = findWikilinkRanges(doc);
+        return {
+          decorations: findWikilinks(doc, null),
+          ranges,
+          activeWikilink: null,
+        };
       },
-      apply(tr, oldState) {
-        // Only recalculate if the document changed
+      apply(tr, oldState: WikilinkPluginState): WikilinkPluginState {
         if (tr.docChanged) {
-          return findWikilinks(tr.doc);
+          // Document changed: rebuild everything
+          const cursorPos = tr.selection?.head ?? null;
+          const ranges = findWikilinkRanges(tr.doc);
+          const active = cursorPos !== null ? findCursorWikilink(ranges, cursorPos) : null;
+          return {
+            decorations: findWikilinks(tr.doc, cursorPos),
+            ranges,
+            activeWikilink: active,
+          };
         }
-        return oldState.map(tr.mapping, tr.doc);
+
+        // Selection changed without doc change
+        const cursorPos = tr.selection?.head ?? null;
+        const active = cursorPos !== null ? findCursorWikilink(oldState.ranges, cursorPos) : null;
+
+        // Only rebuild decorations if the active wikilink changed
+        const oldActive = oldState.activeWikilink;
+        const sameWikilink = active && oldActive &&
+          active.fullStart === oldActive.fullStart && active.fullEnd === oldActive.fullEnd;
+
+        if (!sameWikilink && (active !== null || oldActive !== null)) {
+          return {
+            decorations: findWikilinks(tr.doc, cursorPos),
+            ranges: oldState.ranges,
+            activeWikilink: active,
+          };
+        }
+
+        return oldState;
       },
     },
 
     props: {
       decorations(state) {
-        return this.getState(state);
+        const pluginState = this.getState(state) as WikilinkPluginState | undefined;
+        return pluginState?.decorations || DecorationSet.empty;
       },
 
       // When the user types the closing ]] of a wikilink, automatically

--- a/src/styles.css
+++ b/src/styles.css
@@ -810,6 +810,102 @@ body {
   flex-direction: column;
 }
 
+/* Editor Header */
+.editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-primary);
+  flex-shrink: 0;
+  min-height: 36px;
+}
+
+.editor-header-title-area {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+}
+
+.editor-header-title-input {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 2px 6px;
+  outline: none;
+  width: 100%;
+  max-width: 400px;
+  font-family: inherit;
+  cursor: text;
+}
+
+.editor-header-title-input:hover {
+  background: var(--bg-secondary);
+}
+
+.editor-header-title-input:focus {
+  background: var(--bg-secondary);
+  border-color: var(--accent);
+}
+
+.editor-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.editor-header-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.editor-header-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.editor-header-btn.active {
+  color: var(--accent);
+}
+
+.editor-menu-container {
+  position: relative;
+}
+
+.editor-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+
+.editor-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 1000;
+  min-width: 200px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 4px 0;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  margin-top: 4px;
+}
+
 /* Milkdown Editor Styles */
 .milkdown-editor {
   height: 100%;
@@ -866,6 +962,8 @@ body {
 }
 
 /* Typography */
+.milkdown-editor h1, .milkdown-editor h2, .milkdown-editor h3,
+.milkdown-editor h4, .milkdown-editor h5, .milkdown-editor h6 { position: relative; }
 .milkdown-editor h1 { font-size: 2em; margin: 0.5em 0; }
 .milkdown-editor h2 { font-size: 1.5em; margin: 0.5em 0; }
 .milkdown-editor h3 { font-size: 1.25em; margin: 0.5em 0; }
@@ -877,6 +975,64 @@ body {
 .milkdown-editor blockquote { border-left: 4px solid var(--accent); padding-left: 1em; margin-left: 0; color: var(--text-secondary); }
 .milkdown-editor a { color: var(--accent); text-decoration: none; }
 .milkdown-editor a:hover { text-decoration: underline; }
+
+/* Footnotes */
+.milkdown-editor sup[data-type="footnote_reference"] {
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.75em;
+  vertical-align: super;
+  line-height: 0;
+  padding: 0 1px;
+}
+
+.milkdown-editor sup[data-type="footnote_reference"]::before {
+  content: '[';
+}
+
+.milkdown-editor sup[data-type="footnote_reference"]::after {
+  content: ']';
+}
+
+.milkdown-editor sup[data-type="footnote_reference"]:hover {
+  text-decoration: underline;
+}
+
+.milkdown-editor dl[data-type="footnote_definition"] {
+  display: flex;
+  gap: 8px;
+  margin: 0.5em 0;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border-left: 3px solid var(--accent);
+  border-radius: 0 4px 4px 0;
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+.milkdown-editor dl[data-type="footnote_definition"] dt {
+  color: var(--accent);
+  font-weight: 600;
+  flex-shrink: 0;
+  min-width: 1.5em;
+}
+
+.milkdown-editor dl[data-type="footnote_definition"] dt::before {
+  content: '[';
+}
+
+.milkdown-editor dl[data-type="footnote_definition"] dt::after {
+  content: ']:';
+}
+
+.milkdown-editor dl[data-type="footnote_definition"] dd {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.milkdown-editor dl[data-type="footnote_definition"] dd p {
+  margin: 0;
+}
 
 /* Hashtags */
 .milkdown-editor .hashtag {
@@ -922,6 +1078,23 @@ body {
   width: 0;
   display: inline-block;
   overflow: hidden;
+}
+
+/* Revealed wikilink brackets when cursor is inside the link */
+.milkdown-editor .wikilink-bracket-visible {
+  color: var(--text-secondary, #888);
+  opacity: 0.6;
+}
+
+/* Wikilink in editing mode (cursor inside) — show full raw syntax */
+.milkdown-editor .wikilink-editing {
+  text-decoration: none;
+}
+
+/* Link reveal: expanded [text](url) shown as editable raw text */
+.milkdown-editor .link-expanded {
+  color: var(--text-secondary, #888);
+  font-family: inherit;
 }
 
 /* Task List Items */
@@ -6538,6 +6711,45 @@ body {
 /* Nested paragraphs in callouts */
 .milkdown-editor .callout p + p {
   margin-top: 0.5em;
+}
+
+/* Heading fold chevrons */
+.milkdown-editor .heading-fold-chevron {
+  position: absolute;
+  left: -1.5em;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+  font-size: 0.55em;
+  color: var(--text-secondary, #888);
+  opacity: 0;
+  user-select: none;
+  transition: opacity 0.15s ease;
+}
+
+/* Show chevron on heading hover */
+.milkdown-editor h1:hover > .heading-fold-chevron,
+.milkdown-editor h2:hover > .heading-fold-chevron,
+.milkdown-editor h3:hover > .heading-fold-chevron,
+.milkdown-editor h4:hover > .heading-fold-chevron,
+.milkdown-editor h5:hover > .heading-fold-chevron,
+.milkdown-editor h6:hover > .heading-fold-chevron {
+  opacity: 0.6;
+}
+
+.milkdown-editor .heading-fold-chevron:hover {
+  opacity: 1 !important;
+}
+
+/* Always show chevron when folded */
+.milkdown-editor .heading-fold-chevron.folded {
+  opacity: 0.7;
+  color: var(--accent, #a78bfa);
+}
+
+/* Folded content is hidden */
+.milkdown-editor .heading-folded-content {
+  display: none;
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary
- **Custom keymap**: Enter exits empty list items, creates new task items with unchecked checkbox, moves cursor past `]]` in wikilinks; Shift+Enter inserts hard break
- **Heading fold**: Clickable chevrons in left margin to fold/unfold heading sections; appears on hover, stays visible when folded with accent color
- **Wikilink bracket reveal**: `[[` and `]]` brackets appear when cursor enters a wikilink for editing, hidden otherwise
- **Link input rule**: Typing `[text](url)` auto-converts to a rendered clickable link
- **Link reveal**: Cursor entering a rendered link expands it to editable `[text](url)` showing both display text and URL; collapses back to a link mark when cursor leaves
- **Link click**: Ctrl/Cmd+click opens external URLs in system browser
- **Editor header**: Always-editable filename at top of editor, reader mode toggle (book icon), three-dot menu with file actions (open in new tab, make a copy, move, bookmark, file info, Nostr share/publish, copy path, open in default app, show in explorer, rename, delete)
- **Reader mode**: Toggles ProseMirror to read-only without recreating the editor
- **Footnote CSS** and **editor header CSS** styling

## New files
- `src/lib/editor/keymap-plugin.ts`
- `src/lib/editor/heading-fold-plugin.ts`
- `src/lib/editor/link-input-rule-plugin.ts`

## Modified files
- `src/components/Editor.tsx` — plugin registration, readOnly prop
- `src/App.tsx` — editor header JSX and action handlers
- `src/lib/editor/wikilink-plugin.ts` — cursor-aware bracket reveal
- `src/styles.css` — all new styling