### PR TITLE
feat: render embedded Nostr references in documents (v0.16.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onyx",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Open source knowledge base and note-taking app",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3030,7 +3030,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "onyx"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onyx"
-version = "0.15.0"
+version = "0.16.0"
 description = "Open source knowledge base and note-taking app"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Onyx",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "identifier": "com.onyxnotes.dev",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -27,6 +27,13 @@ import {
   setEmbedVaultPath,
   setEmbedCurrentFilePath,
 } from '../lib/editor/embed-plugin';
+import {
+  nostrEmbedSchema,
+  nostrEmbedView,
+  nostrMentionSchema,
+  nostrMentionView,
+  nostrProsePlugin,
+} from '../lib/editor/nostr-embed-plugin';
 import { highlightPlugin } from '../lib/editor/highlight-plugin';
 import { commentPlugin } from '../lib/editor/comment-plugin';
 import { calloutPlugin } from '../lib/editor/callout-plugin';
@@ -142,6 +149,11 @@ const MilkdownEditor: Component<EditorProps> = (props) => {
       .use(embedView)
       .use(embedInputRule)
       .use(embedProsePlugin)
+      .use(nostrEmbedSchema)
+      .use(nostrEmbedView)
+      .use(nostrMentionSchema)
+      .use(nostrMentionView)
+      .use(nostrProsePlugin)
       .use(vaultUploadPlugin) // Custom upload plugin for paste/drop
       .use(listener)
       .use(hashtagPlugin)

--- a/src/lib/editor/nostr-embed-plugin.ts
+++ b/src/lib/editor/nostr-embed-plugin.ts
@@ -1,0 +1,685 @@
+/**
+ * Milkdown Nostr Embed Plugin
+ *
+ * Renders NIP-21 `nostr:` URIs embedded in documents:
+ *   - nostr:note1 / nostr:nevent1  -> kind-1 note block card
+ *   - nostr:naddr1                 -> long-form (kind-30023) article card
+ *   - nostr:npub1 / nostr:nprofile1 -> inline @name mention chip
+ *
+ * Mirrors the architecture of embed-plugin.ts: a ProseMirror node schema, a
+ * custom node view whose DOM is mutated by an async render function, and a
+ * `$prose` plugin that converts `nostr:` text into nodes on load and on edit.
+ *
+ * The markdown source always keeps the raw `nostr:` URI text; only the live
+ * editor view renders the card/chip (toMarkdown re-emits the URI verbatim).
+ */
+
+import { $prose, $nodeSchema, $view } from '@milkdown/utils';
+import { Plugin, PluginKey, type EditorState, type Transaction } from '@milkdown/prose/state';
+import type { NodeViewConstructor } from '@milkdown/prose/view';
+import type { Node as ProseNode } from '@milkdown/prose/model';
+import { nip19, type Event } from 'nostr-tools';
+import { getSyncEngine } from '../nostr/sync';
+import {
+  escapeHtml,
+  escapeHtmlAttr,
+  sanitizeUrl,
+  sanitizeImageUrl,
+  unescapeHtml,
+} from '../security';
+import { platform } from '@platform';
+import {
+  NOSTR_DETECT_REGEX,
+  parseNostrEntity,
+  truncateBech32,
+  type NotePointer,
+  type ArticlePointer,
+} from '../nostr/entity';
+
+// Plugin key
+export const nostrPluginKey = new PluginKey('nostr-embed');
+
+const NJUMP = 'https://njump.me/';
+
+// ============================================================================
+// Caching - module-level, Promise-valued so concurrent renders of the same
+// reference share a single network round-trip.
+// ============================================================================
+
+interface NostrProfile {
+  name?: string;
+  display_name?: string;
+  displayName?: string;
+  picture?: string;
+  nip05?: string;
+}
+
+const eventCache = new Map<string, Promise<Event | null>>();
+const profileCache = new Map<string, Promise<NostrProfile | null>>();
+
+function cachedEvent(key: string, fetcher: () => Promise<Event | null>): Promise<Event | null> {
+  let p = eventCache.get(key);
+  if (!p) {
+    p = fetcher().catch((e) => {
+      console.error('[nostr-embed] event fetch failed:', e);
+      eventCache.delete(key); // allow a retry on the next render
+      return null;
+    });
+    eventCache.set(key, p);
+  }
+  return p;
+}
+
+function cachedProfile(pubkey: string, relayHints: string[]): Promise<NostrProfile | null> {
+  let p = profileCache.get(pubkey);
+  if (!p) {
+    p = getSyncEngine()
+      .fetchProfileEvent(pubkey, relayHints)
+      .then((ev) => {
+        if (!ev) return null;
+        try {
+          return JSON.parse(ev.content) as NostrProfile;
+        } catch {
+          return null;
+        }
+      })
+      .catch((e) => {
+        console.error('[nostr-embed] profile fetch failed:', e);
+        profileCache.delete(pubkey);
+        return null;
+      });
+    profileCache.set(pubkey, p);
+  }
+  return p;
+}
+
+function fetchPointerEvent(pointer: NotePointer | ArticlePointer): Promise<Event | null> {
+  if (pointer.kind === 'note') {
+    return cachedEvent(`id:${pointer.id}`, () =>
+      getSyncEngine().fetchEventByFilter({ ids: [pointer.id], limit: 1 }, pointer.relays)
+    );
+  }
+  const key = `addr:${pointer.eventKind}:${pointer.pubkey}:${pointer.identifier}`;
+  return cachedEvent(key, () =>
+    getSyncEngine().fetchEventByFilter(
+      {
+        kinds: [pointer.eventKind],
+        authors: [pointer.pubkey],
+        '#d': [pointer.identifier],
+        limit: 1,
+      },
+      pointer.relays
+    )
+  );
+}
+
+// ============================================================================
+// Display helpers
+// ============================================================================
+
+function profileName(profile: NostrProfile | null, pubkey: string): string {
+  const name = profile?.display_name || profile?.displayName || profile?.name;
+  if (name && name.trim()) return name.trim();
+  try {
+    return truncateBech32(nip19.npubEncode(pubkey), 10, 4);
+  } catch {
+    return truncateBech32(pubkey, 10, 4);
+  }
+}
+
+function formatRelativeTime(createdAt: number): string {
+  const diff = Math.max(0, Date.now() / 1000 - createdAt);
+  const mins = Math.floor(diff / 60);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}
+
+function openInClient(bech32: string): void {
+  platform.shell.openExternal(`${NJUMP}${bech32}`).catch(() => {});
+}
+
+// ============================================================================
+// Note content rendering - content is untrusted public data, so escape first
+// then carefully re-introduce only sanitized markup (same pattern as
+// embed-plugin.ts's simpleMarkdownToHtml).
+// ============================================================================
+
+const IMAGE_URL_RE = /https?:\/\/[^\s<]+\.(?:png|jpe?g|gif|webp|avif|bmp|svg)(?:\?[^\s<]*)?/gi;
+const URL_RE = /https?:\/\/[^\s<]+/gi;
+
+// Private-use sentinel used to stash finished markup so later passes don't
+// reprocess URLs that already live inside an <img>/<a> we created. escapeHtml
+// never touches it, and it is stripped from incoming content first.
+const SENTINEL = String.fromCharCode(0xe000);
+
+function renderNoteContent(content: string): string {
+  let html = escapeHtml(content.split(SENTINEL).join(''));
+
+  const tokens: string[] = [];
+  const stash = (markup: string): string => {
+    tokens.push(markup);
+    return `${SENTINEL}${tokens.length - 1}${SENTINEL}`;
+  };
+
+  // 1. Inline images (before generic links so image URLs aren't double-linkified).
+  html = html.replace(IMAGE_URL_RE, (m) => {
+    const safe = sanitizeImageUrl(unescapeHtml(m));
+    if (!safe) return m;
+    return stash(`<img class="nostr-note-img" src="${escapeHtmlAttr(safe)}" alt="" loading="lazy" />`);
+  });
+
+  // 2. Nested nostr: references -> short, non-recursive links (no nested cards).
+  NOSTR_DETECT_REGEX.lastIndex = 0;
+  html = html.replace(NOSTR_DETECT_REGEX, (_m, bech32: string) =>
+    stash(
+      `<a class="nostr-inline-ref" data-bech32="${escapeHtmlAttr(bech32)}">@${escapeHtml(
+        truncateBech32(bech32, 10, 4)
+      )}</a>`
+    )
+  );
+
+  // 3. Linkify remaining URLs (the matched text is already HTML-escaped).
+  html = html.replace(URL_RE, (m) => {
+    const href = escapeHtmlAttr(sanitizeUrl(unescapeHtml(m)));
+    return stash(`<a href="${href}" rel="noopener noreferrer">${m}</a>`);
+  });
+
+  // 4. Newlines -> <br>.
+  html = html.replace(/\n/g, '<br>');
+
+  // Restore stashed markup.
+  const restoreRe = new RegExp(`${SENTINEL}(\\d+)${SENTINEL}`, 'g');
+  return html.replace(restoreRe, (_m, i) => tokens[Number(i)] ?? '');
+}
+
+// ============================================================================
+// Node view rendering
+// ============================================================================
+
+function clear(el: HTMLElement): void {
+  el.textContent = '';
+}
+
+function renderLoading(container: HTMLElement, label: string): void {
+  clear(container);
+  const div = document.createElement('div');
+  div.className = 'nostr-loading';
+  div.textContent = label;
+  container.appendChild(div);
+}
+
+function renderBroken(container: HTMLElement, bech32: string, message: string): void {
+  clear(container);
+  const broken = document.createElement('div');
+  broken.className = 'nostr-broken';
+
+  const text = document.createElement('span');
+  text.className = 'nostr-broken-text';
+  text.textContent = message;
+  broken.appendChild(text);
+
+  const link = document.createElement('a');
+  link.className = 'nostr-open-link';
+  link.textContent = 'Open';
+  link.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    openInClient(bech32);
+  });
+  broken.appendChild(link);
+
+  container.appendChild(broken);
+}
+
+function buildAvatar(pictureUrl: string | undefined): HTMLElement {
+  const safe = sanitizeImageUrl(pictureUrl);
+  if (safe) {
+    const img = document.createElement('img');
+    img.className = 'nostr-note-avatar';
+    img.src = safe;
+    img.alt = '';
+    img.addEventListener('error', () => {
+      const fallback = document.createElement('div');
+      fallback.className = 'nostr-note-avatar';
+      img.replaceWith(fallback);
+    });
+    return img;
+  }
+  const div = document.createElement('div');
+  div.className = 'nostr-note-avatar';
+  return div;
+}
+
+async function renderNoteCard(container: HTMLElement, bech32: string, pointer: NotePointer): Promise<void> {
+  renderLoading(container, 'Loading note...');
+  const event = await fetchPointerEvent(pointer);
+  if (!event) {
+    renderBroken(container, bech32, 'Note not found');
+    return;
+  }
+
+  const profile = await cachedProfile(event.pubkey, pointer.relays);
+
+  clear(container);
+  const card = document.createElement('div');
+  card.className = 'nostr-note';
+
+  // Header: avatar + name + time + open link
+  const header = document.createElement('div');
+  header.className = 'nostr-note-header';
+  header.appendChild(buildAvatar(profile?.picture));
+
+  const meta = document.createElement('div');
+  meta.className = 'nostr-note-meta';
+  const name = document.createElement('span');
+  name.className = 'nostr-note-name';
+  name.textContent = profileName(profile, event.pubkey);
+  meta.appendChild(name);
+  const time = document.createElement('span');
+  time.className = 'nostr-note-time';
+  time.textContent = formatRelativeTime(event.created_at);
+  meta.appendChild(time);
+  header.appendChild(meta);
+
+  const open = document.createElement('a');
+  open.className = 'nostr-open-link';
+  open.textContent = 'Open';
+  open.title = 'Open in Nostr client';
+  open.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    openInClient(bech32);
+  });
+  header.appendChild(open);
+  card.appendChild(header);
+
+  // Content
+  const body = document.createElement('div');
+  body.className = 'nostr-note-content';
+  body.innerHTML = renderNoteContent(event.content);
+  // Nested nostr refs -> open in client
+  body.querySelectorAll<HTMLAnchorElement>('a.nostr-inline-ref').forEach((a) => {
+    const b = a.getAttribute('data-bech32') || '';
+    a.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      openInClient(b);
+    });
+  });
+  // External links -> open externally
+  body.querySelectorAll<HTMLAnchorElement>('a[href]').forEach((a) => {
+    a.addEventListener('click', (e) => {
+      const href = a.getAttribute('href') || '';
+      if (href.startsWith('#')) return;
+      e.preventDefault();
+      e.stopPropagation();
+      platform.shell.openExternal(href).catch(() => {});
+    });
+  });
+  card.appendChild(body);
+
+  container.appendChild(card);
+}
+
+async function renderArticleCard(
+  container: HTMLElement,
+  bech32: string,
+  pointer: ArticlePointer
+): Promise<void> {
+  renderLoading(container, 'Loading article...');
+  const event = await fetchPointerEvent(pointer);
+  if (!event) {
+    renderBroken(container, bech32, 'Article not found');
+    return;
+  }
+
+  const tags = new Map<string, string>();
+  for (const t of event.tags) {
+    if (t.length >= 2 && !tags.has(t[0])) tags.set(t[0], t[1]);
+  }
+  const title = tags.get('title') || 'Untitled';
+  const summary = tags.get('summary') || '';
+  const image = sanitizeImageUrl(tags.get('image'));
+
+  const profile = await cachedProfile(event.pubkey, pointer.relays);
+
+  clear(container);
+  const card = document.createElement('div');
+  card.className = 'nostr-article';
+  card.addEventListener('click', () => openInClient(bech32));
+
+  if (image) {
+    const img = document.createElement('img');
+    img.className = 'nostr-article-image';
+    img.src = image;
+    img.alt = '';
+    img.addEventListener('error', () => img.remove());
+    card.appendChild(img);
+  }
+
+  const bodyWrap = document.createElement('div');
+  bodyWrap.className = 'nostr-article-body';
+
+  const titleEl = document.createElement('div');
+  titleEl.className = 'nostr-article-title';
+  titleEl.textContent = title;
+  bodyWrap.appendChild(titleEl);
+
+  if (summary) {
+    const sum = document.createElement('div');
+    sum.className = 'nostr-article-summary';
+    sum.textContent = summary;
+    bodyWrap.appendChild(sum);
+  }
+
+  const byline = document.createElement('div');
+  byline.className = 'nostr-article-byline';
+  byline.textContent = `${profileName(profile, event.pubkey)} - ${formatRelativeTime(event.created_at)}`;
+  bodyWrap.appendChild(byline);
+
+  card.appendChild(bodyWrap);
+  container.appendChild(card);
+}
+
+/** Dispatch a block reference (note / article) to the right renderer. */
+function renderBlock(container: HTMLElement, ref: string): void {
+  clear(container);
+  const parsed = parseNostrEntity(ref);
+  if (!parsed) {
+    renderBroken(container, ref.replace(/^nostr:/, ''), 'Invalid Nostr reference');
+    return;
+  }
+  const { bech32, pointer } = parsed;
+  if (pointer.kind === 'note') {
+    renderNoteCard(container, bech32, pointer).catch(() => renderBroken(container, bech32, 'Note not found'));
+  } else if (pointer.kind === 'article') {
+    renderArticleCard(container, bech32, pointer).catch(() =>
+      renderBroken(container, bech32, 'Article not found')
+    );
+  } else {
+    renderBroken(container, bech32, 'Unsupported reference');
+  }
+}
+
+async function renderMention(container: HTMLElement, bech32: string, pubkey: string, relays: string[]): Promise<void> {
+  container.textContent = `@${truncateBech32(bech32, 10, 4)}`;
+  if (!pubkey) return;
+  const profile = await cachedProfile(pubkey, relays);
+  if (profile) {
+    container.textContent = `@${profileName(profile, pubkey)}`;
+  }
+}
+
+// ============================================================================
+// Schemas
+// ============================================================================
+
+/** Block card node for notes (note/nevent) and articles (naddr). */
+export const nostrEmbedSchema = $nodeSchema('nostr_embed', () => ({
+  inline: false,
+  group: 'block',
+  selectable: true,
+  draggable: true,
+  atom: true,
+  marks: '',
+  attrs: {
+    uri: { default: '' },
+    bech32: { default: '' },
+    kind: { default: 'note' },
+  },
+  parseDOM: [
+    {
+      tag: 'div[data-type="nostr-embed"]',
+      getAttrs: (dom: HTMLElement) => ({
+        uri: dom.getAttribute('data-uri') || '',
+        bech32: dom.getAttribute('data-bech32') || '',
+        kind: dom.getAttribute('data-kind') || 'note',
+      }),
+    },
+  ],
+  toDOM: (node) => [
+    'div',
+    {
+      'data-type': 'nostr-embed',
+      'data-uri': node.attrs.uri,
+      'data-bech32': node.attrs.bech32,
+      'data-kind': node.attrs.kind,
+      class: 'nostr-embed',
+    },
+  ],
+  parseMarkdown: {
+    match: ({ type }) => type === 'nostr_embed',
+    runner: (state, node, type) => {
+      state.addNode(type, {
+        uri: node.uri as string,
+        bech32: node.bech32 as string,
+        kind: node.kind as string,
+      });
+    },
+  },
+  toMarkdown: {
+    match: (node) => node.type.name === 'nostr_embed',
+    runner: (state, node) => {
+      // Re-emit the raw URI via an 'html' node so remark-stringify does not
+      // escape it (same approach the file-embed plugin uses for ![[...]]).
+      state.addNode('html', undefined, node.attrs.uri);
+    },
+  },
+}));
+
+/** Inline mention chip for profiles (npub/nprofile). */
+export const nostrMentionSchema = $nodeSchema('nostr_mention', () => ({
+  inline: true,
+  group: 'inline',
+  atom: true,
+  selectable: true,
+  marks: '',
+  attrs: {
+    uri: { default: '' },
+    bech32: { default: '' },
+    pubkey: { default: '' },
+  },
+  parseDOM: [
+    {
+      tag: 'span[data-type="nostr-mention"]',
+      getAttrs: (dom: HTMLElement) => ({
+        uri: dom.getAttribute('data-uri') || '',
+        bech32: dom.getAttribute('data-bech32') || '',
+        pubkey: dom.getAttribute('data-pubkey') || '',
+      }),
+    },
+  ],
+  toDOM: (node) => [
+    'span',
+    {
+      'data-type': 'nostr-mention',
+      'data-uri': node.attrs.uri,
+      'data-bech32': node.attrs.bech32,
+      'data-pubkey': node.attrs.pubkey,
+      class: 'nostr-mention',
+    },
+  ],
+  parseMarkdown: {
+    match: ({ type }) => type === 'nostr_mention',
+    runner: (state, node, type) => {
+      state.addNode(type, {
+        uri: node.uri as string,
+        bech32: node.bech32 as string,
+        pubkey: node.pubkey as string,
+      });
+    },
+  },
+  toMarkdown: {
+    match: (node) => node.type.name === 'nostr_mention',
+    runner: (state, node) => {
+      // Inline text node carrying the raw URI; nostr: URIs contain no chars
+      // remark-stringify escapes, so they round-trip verbatim.
+      state.addNode('text', undefined, node.attrs.uri as string);
+    },
+  },
+}));
+
+// ============================================================================
+// Node views
+// ============================================================================
+
+export const nostrEmbedView = $view(nostrEmbedSchema.node, (): NodeViewConstructor => {
+  return (node) => {
+    const dom = document.createElement('div');
+    dom.className = 'nostr-embed';
+    dom.contentEditable = 'false';
+
+    let bech32 = node.attrs.bech32 as string;
+    let uri = node.attrs.uri as string;
+    renderBlock(dom, bech32 || uri);
+
+    return {
+      dom,
+      update: (updated) => {
+        if (updated.type.name !== 'nostr_embed') return false;
+        if (updated.attrs.bech32 !== bech32 || updated.attrs.uri !== uri) {
+          bech32 = updated.attrs.bech32;
+          uri = updated.attrs.uri;
+          renderBlock(dom, bech32 || uri);
+        }
+        return true;
+      },
+      selectNode: () => dom.classList.add('selected'),
+      deselectNode: () => dom.classList.remove('selected'),
+      stopEvent: () => false,
+      ignoreMutation: () => true,
+    };
+  };
+});
+
+export const nostrMentionView = $view(nostrMentionSchema.node, (): NodeViewConstructor => {
+  return (node) => {
+    const dom = document.createElement('span');
+    dom.className = 'nostr-mention';
+    dom.contentEditable = 'false';
+
+    let bech32 = node.attrs.bech32 as string;
+    let pubkey = node.attrs.pubkey as string;
+
+    dom.addEventListener('click', (e) => {
+      e.preventDefault();
+      openInClient(bech32);
+    });
+
+    renderMention(dom, bech32, pubkey, []);
+
+    return {
+      dom,
+      update: (updated) => {
+        if (updated.type.name !== 'nostr_mention') return false;
+        if (updated.attrs.bech32 !== bech32 || updated.attrs.pubkey !== pubkey) {
+          bech32 = updated.attrs.bech32;
+          pubkey = updated.attrs.pubkey;
+          renderMention(dom, bech32, pubkey, []);
+        }
+        return true;
+      },
+      stopEvent: () => false,
+      ignoreMutation: () => true,
+    };
+  };
+});
+
+// ============================================================================
+// Text -> node conversion
+// ============================================================================
+
+/**
+ * Find every `nostr:` URI in the document and convert it to a node.
+ * - Profiles (npub/nprofile) become inline mention chips wherever they appear.
+ * - Notes/articles become block cards ONLY when the URI is the sole content of
+ *   its paragraph (a block node cannot be inserted mid-paragraph); otherwise
+ *   they are left as plain text.
+ */
+function convertNostrInDoc(state: EditorState): Transaction | null {
+  const embedType = state.schema.nodes.nostr_embed;
+  const mentionType = state.schema.nodes.nostr_mention;
+  if (!embedType || !mentionType) return null;
+
+  type Repl = { from: number; to: number; node: ProseNode; sortPos: number };
+  const repls: Repl[] = [];
+
+  state.doc.descendants((node, pos) => {
+    if (!node.isText || !node.text) return;
+    const text = node.text;
+    NOSTR_DETECT_REGEX.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = NOSTR_DETECT_REGEX.exec(text)) !== null) {
+      const full = m[0]; // includes the nostr: prefix
+      const bech32 = m[1];
+      const parsed = parseNostrEntity(bech32);
+      if (!parsed) continue;
+      const uri = `nostr:${bech32}`;
+      const matchStart = pos + m.index;
+      const matchEnd = matchStart + full.length;
+
+      if (parsed.pointer.kind === 'mention') {
+        const mentionNode = mentionType.create({ uri, bech32, pubkey: parsed.pointer.pubkey });
+        repls.push({ from: matchStart, to: matchEnd, node: mentionNode, sortPos: matchStart });
+      } else {
+        // note / article -> block card, only if it's the sole content of its block
+        const $pos = state.doc.resolve(matchStart);
+        const parent = $pos.parent;
+        if (parent.isTextblock && parent.textContent.trim() === full) {
+          const kind = parsed.pointer.kind === 'article' ? 'article' : 'note';
+          const embedNode = embedType.create({ uri, bech32, kind });
+          repls.push({ from: $pos.before(), to: $pos.after(), node: embedNode, sortPos: $pos.before() });
+        }
+        // otherwise: leave as plain text
+      }
+    }
+  });
+
+  if (!repls.length) return null;
+
+  // Apply highest-position-first so earlier positions stay valid.
+  repls.sort((a, b) => b.sortPos - a.sortPos);
+  const tr = state.tr;
+  for (const r of repls) {
+    tr.replaceWith(r.from, r.to, r.node);
+  }
+  return tr;
+}
+
+/**
+ * Prose plugin: convert existing `nostr:` text on load and on document changes.
+ */
+export const nostrProsePlugin = $prose(() => {
+  return new Plugin({
+    key: nostrPluginKey,
+
+    view(editorView) {
+      // Convert after the editor is ready (matches embed plugin timing).
+      setTimeout(() => {
+        const tr = convertNostrInDoc(editorView.state);
+        if (tr) {
+          tr.setMeta(nostrPluginKey, true);
+          editorView.dispatch(tr);
+        }
+      }, 0);
+      return {};
+    },
+
+    appendTransaction(transactions, _oldState, newState) {
+      if (!transactions.some((tr) => tr.docChanged && !tr.getMeta(nostrPluginKey))) return null;
+      const tr = convertNostrInDoc(newState);
+      if (tr) {
+        tr.setMeta(nostrPluginKey, true); // prevent recursion
+        return tr;
+      }
+      return null;
+    },
+  });
+});

--- a/src/lib/nostr/entity.ts
+++ b/src/lib/nostr/entity.ts
@@ -1,0 +1,107 @@
+/**
+ * NIP-19 / NIP-21 entity parsing for embedded Nostr references.
+ *
+ * Decodes `nostr:` URIs (NIP-21) into a normalized pointer so the editor can
+ * decide how to render them: kind-1 notes and long-form articles as block
+ * cards, profiles as inline mention chips.
+ */
+
+import { nip19 } from 'nostr-tools';
+
+/**
+ * Matches a NIP-21 `nostr:` URI for the entity types we render. The data part
+ * uses the bech32 charset (per NIP-19). `g` flag — callers MUST reset
+ * `lastIndex` before reusing it on a new string.
+ */
+export const NOSTR_DETECT_REGEX =
+  /nostr:((?:npub1|nprofile1|note1|nevent1|naddr1)[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+
+export type NostrEntityKind = 'note' | 'article' | 'mention';
+
+export interface NotePointer {
+  kind: 'note';
+  /** hex event id */
+  id: string;
+  relays: string[];
+  author?: string;
+}
+
+export interface ArticlePointer {
+  kind: 'article';
+  /** the addressable event kind embedded in the naddr (e.g. 30023) */
+  eventKind: number;
+  pubkey: string;
+  identifier: string;
+  relays: string[];
+}
+
+export interface MentionPointer {
+  kind: 'mention';
+  /** hex pubkey */
+  pubkey: string;
+  relays: string[];
+}
+
+export type NostrPointer = NotePointer | ArticlePointer | MentionPointer;
+
+export interface ParsedNostrEntity {
+  /** the bech32 entity without the `nostr:` prefix */
+  bech32: string;
+  pointer: NostrPointer;
+}
+
+/**
+ * Parse a bech32 entity (with or without the `nostr:` prefix) into a
+ * normalized pointer. Returns null for unsupported or malformed input.
+ */
+export function parseNostrEntity(input: string): ParsedNostrEntity | null {
+  const bech32 = input.startsWith('nostr:') ? input.slice('nostr:'.length) : input;
+
+  let decoded: ReturnType<typeof nip19.decode>;
+  try {
+    decoded = nip19.decode(bech32);
+  } catch {
+    return null;
+  }
+
+  switch (decoded.type) {
+    case 'note':
+      return { bech32, pointer: { kind: 'note', id: decoded.data, relays: [] } };
+    case 'nevent':
+      return {
+        bech32,
+        pointer: {
+          kind: 'note',
+          id: decoded.data.id,
+          relays: decoded.data.relays ?? [],
+          author: decoded.data.author,
+        },
+      };
+    case 'npub':
+      return { bech32, pointer: { kind: 'mention', pubkey: decoded.data, relays: [] } };
+    case 'nprofile':
+      return {
+        bech32,
+        pointer: { kind: 'mention', pubkey: decoded.data.pubkey, relays: decoded.data.relays ?? [] },
+      };
+    case 'naddr':
+      return {
+        bech32,
+        pointer: {
+          kind: 'article',
+          eventKind: decoded.data.kind,
+          pubkey: decoded.data.pubkey,
+          identifier: decoded.data.identifier,
+          relays: decoded.data.relays ?? [],
+        },
+      };
+    default:
+      return null;
+  }
+}
+
+/** Truncate a long bech32 string for compact display, e.g. npub1abc…wxyz. */
+export function truncateBech32(bech32: string, head = 12, tail = 6): string {
+  if (bech32.length <= head + tail + 1) return bech32;
+  return `${bech32.slice(0, head)}…${bech32.slice(-tail)}`;
+}

--- a/src/lib/nostr/sync.ts
+++ b/src/lib/nostr/sync.ts
@@ -5,7 +5,7 @@
  * Supports both local signing (nsec) and remote signing (NIP-46 bunker).
  */
 
-import { SimplePool, finalizeEvent, nip44, nip19, nip17, type Event } from 'nostr-tools';
+import { SimplePool, finalizeEvent, nip44, nip19, nip17, type Event, type Filter } from 'nostr-tools';
 import { v4 as uuidv4 } from 'uuid';
 import { hexToBytes } from '@noble/hashes/utils.js';
 import {
@@ -1280,6 +1280,39 @@ export class SyncEngine {
   public getFileNaddr(d: string): string | null {
     if (!this.pubkey) return null;
     return this.encodeNaddr(KIND_FILE, this.pubkey, d, this.config.relays);
+  }
+
+  // ============================================
+  // Public event fetching (for embedded Nostr references)
+  // ============================================
+
+  /**
+   * Fetch a single event matching a filter, merging optional relay hints
+   * (from a nevent/nprofile/naddr) with the configured relays. Returns the
+   * newest matching event (relevant for addressable/replaceable events such
+   * as kind-30023 articles), or null if none arrive before the timeout.
+   *
+   * Public so the editor's Nostr-embed plugin can reuse the shared relay
+   * pool and the user's relay config rather than opening its own sockets.
+   */
+  public async fetchEventByFilter(filter: Filter, relayHints: string[] = []): Promise<Event | null> {
+    const relays = Array.from(new Set([...this.config.relays, ...relayHints])).slice(0, 12);
+    try {
+      const events = await this.pool.querySync(relays, filter, { maxWait: 5000 });
+      if (!events.length) return null;
+      return events.reduce((newest, ev) => (ev.created_at > newest.created_at ? ev : newest));
+    } catch (e) {
+      console.error('[SyncEngine] fetchEventByFilter failed:', e);
+      return null;
+    }
+  }
+
+  /**
+   * Fetch a user's kind-0 metadata event. Returns the raw event (the caller
+   * parses the JSON content), or null if not found.
+   */
+  public async fetchProfileEvent(pubkey: string, relayHints: string[] = []): Promise<Event | null> {
+    return this.fetchEventByFilter({ kinds: [0], authors: [pubkey], limit: 1 }, relayHints);
   }
 
   // ============================================

--- a/src/styles.css
+++ b/src/styles.css
@@ -6239,6 +6239,206 @@ body {
 }
 
 /* ============================================================================
+   Nostr Embeds - rendered nostr: references (notes, articles, mentions)
+   ============================================================================ */
+
+.nostr-embed {
+  margin: 1em 0;
+  user-select: none;
+}
+
+.nostr-embed.selected {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 12px;
+}
+
+/* Note card */
+.nostr-note {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.nostr-note-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.nostr-note-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--bg-tertiary);
+  flex-shrink: 0;
+}
+
+.nostr-note-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.nostr-note-name {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.nostr-note-time {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.nostr-note-content {
+  padding: 12px 16px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.nostr-note-content a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.nostr-note-content a:hover {
+  text-decoration: underline;
+}
+
+.nostr-note-img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 8px 0;
+  border-radius: 8px;
+}
+
+.nostr-inline-ref {
+  color: var(--accent);
+  cursor: pointer;
+}
+
+/* Open-in-client link */
+.nostr-open-link {
+  margin-left: auto;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 13px;
+  text-decoration: none;
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.nostr-open-link:hover {
+  color: var(--accent);
+  background: var(--accent-muted);
+}
+
+/* Article card */
+.nostr-article {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.nostr-article:hover {
+  border-color: var(--accent);
+}
+
+.nostr-article-image {
+  width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+  display: block;
+}
+
+.nostr-article-body {
+  padding: 12px 16px;
+}
+
+.nostr-article-title {
+  font-weight: 600;
+  font-size: 16px;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.nostr-article-summary {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 8px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.nostr-article-byline {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* Inline mention chip */
+.nostr-mention {
+  color: var(--accent);
+  background: var(--accent-muted);
+  padding: 1px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.nostr-mention:hover {
+  background: var(--accent);
+  color: var(--accent-text);
+}
+
+/* Loading + broken states */
+.nostr-loading {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  font-size: 13px;
+}
+
+.nostr-broken {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  background: var(--bg-secondary);
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+/* ============================================================================
    Upload Progress Indicator - Drag-and-drop / Clipboard paste
    ============================================================================ */
 


### PR DESCRIPTION
## Summary

Paste a NIP-21 `nostr:` URI into a document and it renders inline in the live editor view, while the markdown source keeps the raw URI:

- `nostr:note1…` / `nostr:nevent1…` → **kind-1 note card** (author avatar + name from kind-0 profile, content, relative time, open-in-client link)
- `nostr:naddr1…` → **long-form (kind-30023) article preview card** (title/summary/image from tags)
- `nostr:npub1…` / `nostr:nprofile1…` → inline **@name mention chip**

Note content gets URLs linkified, image URLs shown inline, newlines preserved, and nested `nostr:` refs become short non-recursive links. All untrusted content is sanitized before render (escape-first, reusing `security.ts` helpers).

## Implementation

- New Milkdown/ProseMirror plugin `src/lib/editor/nostr-embed-plugin.ts`, mirroring the existing file-embed architecture (node schema + node view + `$prose` text→node conversion). Block cards convert only when the URI is the sole content of its paragraph; mentions convert inline anywhere. `toMarkdown` re-emits the raw URI so documents round-trip.
- New pure decode util `src/lib/nostr/entity.ts` (NIP-19/21 → normalized pointer).
- New public `SyncEngine.fetchEventByFilter` / `fetchProfileEvent` reusing the shared relay pool + user relay config, with in-memory Promise de-dup caching.
- Wired into `Editor.tsx`; styles added in `styles.css` using existing theme tokens.
- Version bumped to `0.16.0`.

## Verification

- `npm run typecheck` and `npm run build` clean.
- `.deb` built, installed, and manually verified: notes/articles render as cards, npub renders as an inline chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)