### PR TITLE
fix: prevent blank screen on Linux Wayland (WebKitGTK DMABUF)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,18 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Workaround for WebKitGTK rendering a blank/white screen on some Linux
+    // Wayland setups (e.g. Nvidia, Hyprland) where the DMABUF renderer fails.
+    // See https://github.com/derekross/onyx/issues/19. Only applied on Linux,
+    // and never overrides a value the user has already set (allows opting out
+    // with WEBKIT_DISABLE_DMABUF_RENDERER=0). Must run before the webview is
+    // created, which is why it lives here at the top of main().
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+    }
+
     onyx_lib::run();
 }


### PR DESCRIPTION
## Problem

Closes #19. On some Linux Wayland desktops (reported on Arch/CachyOS with Hyprland, also Nvidia), the Onyx AppImage opens to a completely blank/white screen. Two users confirmed the only way to launch it was the workaround:

```
LD_PRELOAD=/usr/lib/libwayland-client.so ./Onyx.AppImage
```

This is the well-known WebKitGTK-on-Wayland issue where the DMABUF renderer fails and the page never paints.

## Fix

Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` at the very top of `main()`, before the Tauri webview is created.

- Gated to Linux with `#[cfg(target_os = "linux")]` — no effect on macOS/Windows.
- Only set when the user hasn't already provided the variable, so it can be opted out of with `WEBKIT_DISABLE_DMABUF_RENDERER=0`.
- Applied unconditionally on Linux (not Wayland-only) because the DMABUF renderer can also misbehave on some X11/Nvidia setups; disabling it is low-risk.

`cargo check` passes.

## Caveats / notes

- This is the **standard, accepted mitigation** for this class of blank-screen bug, but it is a workaround rather than a root-cause fix — the `LD_PRELOAD libwayland-client` symptom points at a deeper AppImage bundling/symbol-resolution issue. The env var sidesteps the renderer path that trips over it.
- I don't have a Wayland/Hyprland/Nvidia machine to confirm the end-to-end AppImage fix. @Bilel-Eljaamii @Storm-Trooper5555 — a test build would be appreciated to confirm.
- If DMABUF-only proves insufficient for anyone, the next lever is `WEBKIT_DISABLE_COMPOSITING_MODE=1` (heavier, kept out for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)