### PR TITLE
fix: enable undo/redo in the Milkdown editor

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -37,6 +37,7 @@ import {
 import { highlightPlugin } from '../lib/editor/highlight-plugin';
 import { commentPlugin } from '../lib/editor/comment-plugin';
 import { calloutPlugin } from '../lib/editor/callout-plugin';
+import { historyPlugin, historyKeymap } from '../lib/editor/history';
 import { AssetIndex } from '../lib/editor/asset-index';
 import {
   vaultUploadPlugin,
@@ -145,6 +146,9 @@ const MilkdownEditor: Component<EditorProps> = (props) => {
       .config(nord)
       .use(customCommonmark)
       .use(gfm)
+      // Undo/redo (commonmark preset does not include prosemirror-history)
+      .use(historyPlugin)
+      .use(historyKeymap)
       .use(embedSchema)
       .use(embedView)
       .use(embedInputRule)

--- a/src/lib/editor/history.ts
+++ b/src/lib/editor/history.ts
@@ -1,0 +1,25 @@
+import { $prose } from '@milkdown/utils';
+import { history, undo, redo } from '@milkdown/prose/history';
+import { keymap } from '@milkdown/prose/keymap';
+
+// Undo/redo support for the Milkdown editor.
+//
+// @milkdown/preset-commonmark does not bundle prosemirror-history, so without
+// these plugins Ctrl+Z / Cmd+Z does nothing in the live (WYSIWYG) editor.
+// We wire up the history state plugin plus the standard keybindings using the
+// prosemirror-history / prosemirror-keymap re-exports that ship with
+// @milkdown/prose, so no extra dependency is required.
+//
+// Mod-z      -> undo
+// Mod-y      -> redo (Windows/Linux convention)
+// Shift-Mod-z -> redo (macOS convention)
+
+export const historyPlugin = $prose(() => history());
+
+export const historyKeymap = $prose(() =>
+  keymap({
+    'Mod-z': undo,
+    'Mod-y': redo,
+    'Shift-Mod-z': redo,
+  })
+);


### PR DESCRIPTION
## Problem

Closes #17. Pressing **Ctrl+Z / Cmd+Z** does nothing in the live (WYSIWYG) editor — text input and deletions cannot be undone.

Root cause: the editor is Milkdown, and `@milkdown/preset-commonmark@7.18.0` does **not** bundle `prosemirror-history`. The editor registered ~24 plugins, none providing history, and nothing bound `Mod-z`. (The raw-source `<textarea>` view was unaffected — it has native browser undo.)

## Fix

New `src/lib/editor/history.ts` registers the ProseMirror history plugin plus the standard keybindings, wired into the editor right after the commonmark/gfm presets:

- `Mod-z` → undo
- `Mod-y` → redo (Windows/Linux)
- `Shift-Mod-z` → redo (macOS)

**Zero new dependencies** — `prosemirror-history` (v1.5.0) and `prosemirror-keymap` already ship transitively and are re-exported by `@milkdown/prose/history` and `@milkdown/prose/keymap`.

The existing per-file doc-swap (`Editor.tsx`) already builds a fresh `EditorState` on tab switch, which correctly resets history per document — its comments already anticipated history being present, so no change was needed there.

## Verification

- `npm run typecheck` and `npm run build` pass.
- Verified the underlying `prosemirror-history` undo/redo against the actual installed package with a focused offline test (insert → undo reverts → redo reapplies). `Mod-z` has no conflicting binding in the commonmark keymap, so registration order is irrelevant.
- Worth a quick manual smoke test on desktop: type, then Cmd/Ctrl+Z to undo and Shift+Cmd/Ctrl+Z (or Ctrl+Y) to redo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)