### PR TITLE
fix: don't exit macOS fullscreen when Escape closes a dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1430,6 +1430,13 @@ const App: Component = () => {
         e.preventDefault();
         handleOpenTemplatesPicker();
       } else if (e.key === 'Escape') {
+        // Closing a modal with Escape must consume the event, otherwise the
+        // OS default (e.g. exiting native fullscreen on macOS) also fires.
+        // Only preventDefault when a modal is actually open so Escape keeps
+        // its normal behavior (IME cancel, etc.) when nothing is showing.
+        if (showQuickSwitcher() || showCommandPalette() || showSearch() || showTemplatesModal()) {
+          e.preventDefault();
+        }
         setShowQuickSwitcher(false);
         setShowCommandPalette(false);
         setShowSearch(false);

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -52,6 +52,10 @@ const CommandPalette: Component<CommandPaletteProps> = (props) => {
         props.onClose();
       }
     } else if (e.key === 'Escape') {
+      // Consume Escape so the OS default (e.g. exit native fullscreen on
+      // macOS) does not also fire while closing the dialog.
+      e.preventDefault();
+      e.stopPropagation();
       props.onClose();
     }
   };

--- a/src/components/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher.tsx
@@ -78,6 +78,10 @@ const QuickSwitcher: Component<QuickSwitcherProps> = (props) => {
         props.onSelect(selected.path);
       }
     } else if (e.key === 'Escape') {
+      // Consume Escape so the OS default (e.g. exit native fullscreen on
+      // macOS) does not also fire while closing the dialog.
+      e.preventDefault();
+      e.stopPropagation();
       props.onClose();
     }
   };

--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -65,6 +65,10 @@ const SearchPanel: Component<SearchPanelProps> = (props) => {
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
+      // Consume Escape so the OS default (e.g. exit native fullscreen on
+      // macOS) does not also fire while closing the dialog.
+      e.preventDefault();
+      e.stopPropagation();
       props.onClose();
     } else if (e.key === 'Enter') {
       performSearch(query());


### PR DESCRIPTION
## Problem

Closes #16. On macOS, when the app is in native fullscreen and you open the search dialog (Cmd+O) then press **Escape** to close it, Escape *also* exits macOS fullscreen. The dialog should close without leaving fullscreen.

Root cause: the Escape handlers closed the dialog but never called `e.preventDefault()`, so the browser/OS default action for Escape (exit native fullscreen) still fired. This affected every keyboard-opened dialog, not just search.

## Fix

Add `e.preventDefault()` / `e.stopPropagation()` to the Escape branch of each dialog:

- `QuickSwitcher.tsx` (Cmd+O)
- `CommandPalette.tsx` (Cmd+P)
- `SearchPanel.tsx` (Cmd+Shift+F)
- the global handler in `App.tsx` — guarded so it only `preventDefault`s when a modal is actually open (preserving Escape's normal behavior otherwise). This also covers the Templates modal (Cmd+T), which has no per-component Escape handler.

`npm run typecheck` passes.

## Caveat — needs macOS verification

The app uses **native** macOS fullscreen (the green-button/window-manager kind), not the JS Fullscreen API (`requestFullscreen` is not used anywhere). `preventDefault()` on the Escape keydown is the standard web-level fix and usually suppresses the native exit inside WKWebView because the key routes through web content first — but I can't verify on macOS from Linux.

@sybenx — could you confirm on your macOS build that Escape now closes the search dialog without leaving fullscreen? If the webview-level fix proves insufficient, the fallback is to intercept Escape at the Tauri/Rust window level instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)