### PR TITLE
chore: release v0.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onyx",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Open source knowledge base and note-taking app",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3030,7 +3030,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "onyx"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onyx"
-version = "0.16.0"
+version = "0.16.1"
 description = "Open source knowledge base and note-taking app"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Onyx",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "identifier": "com.onyxnotes.dev",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bug-fix release bundling the three fixes just merged:

- #19 — Wayland blank-screen workaround (`WEBKIT_DISABLE_DMABUF_RENDERER`)
- #17 — editor undo/redo (Ctrl/Cmd+Z)
- #16 — Escape no longer exits macOS fullscreen when closing dialogs

Version bumped `0.16.0 → 0.16.1` across `package.json`, `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`. Tagging `v0.16.1` after merge triggers the multi-platform release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)