### PR TITLE
chore: migrate zapstore.yaml to the zsp config format

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -13,8 +13,7 @@ description: |
 license: MIT
 repository: https://github.com/derekross/onyx
 website: https://onyxnotes.dev
-assets:
-  - app-universal-release.apk
+match: app-universal-release\.apk$
 metadata_sources:
   - github
 tags:


### PR DESCRIPTION
Publishing v0.16.2 to Zapstore is blocked on this file.

The current publisher is [zsp](https://github.com/zapstore/zsp) (v0.4.16). It rejects the existing file outright:

```
Error: zapstore-cli config format detected. Run zsp publish without --quiet to migrate
```

and its auto-migrator then fails on `tags:` (`line 21: cannot unmarshal !!seq into string`), because this file is a hybrid of the two schemas. So it has to be written in the new format by hand.

**The only change:** the asset selector moved from an `assets:` list to a `match:` regex. Every other field is untouched.

### Verified

Dry run against the real v0.16.2 APK (`SIGN_WITH=<npub> zsp publish <apk> --offline`, nothing published):

| event | d tag |
|---|---|
| 32267 | `com.onyxnotes.dev` |
| 30063 | `com.onyxnotes.dev@0.16.2` |
| 3063 | version 0.16.2, versionCode 16002, universal ABIs |

That matches the existing listing, and 16002 > the live 15000, so it is a real update rather than a fork or a downgrade.

APK signing certificate is `CN=Soapbox`, SHA-256 `0f68adf862afd9a63cc18110512c992eb66e2a1adf824979a104b223763fc56a` — identical across v0.15.0, v0.16.1 and v0.16.2, so installed users can update.

Publishing itself still needs Derek: the listing is signed by `3f770d65…`, his identity key.