### PR TITLE
fix: gate the WebKitGTK DMABUF workaround, and wrap long unbroken strings

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,16 +1,40 @@
 // Prevents additional console window on Windows in release
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+// Detects the Linux setups where the WebKitGTK DMABUF renderer is known to
+// fail and render a blank/white screen. Disabling that renderer makes WebKitGTK
+// composite through CPU shared memory instead of zero-copy GPU buffers, which
+// costs CPU in both this process and the compositor, so it is only worth paying
+// where it is actually needed.
+#[cfg(target_os = "linux")]
+fn needs_dmabuf_workaround() -> bool {
+    // Proprietary Nvidia driver.
+    let nvidia = std::path::Path::new("/proc/driver/nvidia/version").exists()
+        || std::path::Path::new("/sys/module/nvidia").exists();
+
+    // Hyprland, reported independently of the GPU vendor.
+    let hyprland = std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some()
+        || std::env::var("XDG_CURRENT_DESKTOP")
+            .map(|desktop| desktop.to_ascii_lowercase().contains("hyprland"))
+            .unwrap_or(false);
+
+    nvidia || hyprland
+}
+
 fn main() {
     // Workaround for WebKitGTK rendering a blank/white screen on some Linux
     // Wayland setups (e.g. Nvidia, Hyprland) where the DMABUF renderer fails.
-    // See https://github.com/derekross/onyx/issues/19. Only applied on Linux,
-    // and never overrides a value the user has already set (allows opting out
-    // with WEBKIT_DISABLE_DMABUF_RENDERER=0). Must run before the webview is
-    // created, which is why it lives here at the top of main().
+    // See https://github.com/derekross/onyx/issues/19. Scoped to the setups
+    // that need it, since disabling the DMABUF renderer costs CPU everywhere
+    // else, and never overrides a value the user has already set (so it can be
+    // forced on with WEBKIT_DISABLE_DMABUF_RENDERER=1 or off with =0). Must run
+    // before the webview is created, which is why it lives here at the top of
+    // main().
     #[cfg(target_os = "linux")]
     {
-        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none()
+            && needs_dmabuf_workaround()
+        {
             std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -859,6 +859,10 @@ body {
   min-height: 100%;
   outline: none;
   padding-bottom: 50vh;
+  /* Wrap long unbroken strings (URLs, npubs, tokens) instead of overflowing.
+     `overflow-wrap: anywhere` works where `word-wrap: break-word` (from the
+     nord theme) fails in WebKit: long words at the start of a line. */
+  overflow-wrap: anywhere;
 }
 
 .milkdown-editor .ProseMirror:focus {


### PR DESCRIPTION
These two changes were sitting uncommitted in `~/Projects/onyx` (mtimes Jul 24 and Jul 27) and were blocking that checkout from being clean. They are real work, so rather than discard them they are preserved here. Both are independent of the v0.16.2 release.

**DMABUF workaround, `src-tauri/src/main.rs`** — the fix for #19 was applied on *every* Linux system. Disabling the DMABUF renderer makes WebKitGTK composite through CPU shared memory instead of zero-copy GPU buffers, which costs CPU in both this process and the compositor. It is now scoped to the setups where the blank-screen bug is actually reported — proprietary Nvidia, or Hyprland — and an explicitly set `WEBKIT_DISABLE_DMABUF_RENDERER` still wins in either direction.

**Text wrapping, `src/styles.css`** — `overflow-wrap: anywhere` on the editor, so long unbroken strings (URLs, npubs, tokens) wrap instead of overflowing. Covers the case `word-wrap: break-word` from the nord theme misses in WebKit: a long word at the start of a line.

Not reviewed or tested by me beyond `cargo test` on the branch — these are Derek own edits, opened so the working tree could be cleaned without losing them.